### PR TITLE
stream: handle abort in iter consumers

### DIFF
--- a/lib/internal/streams/iter/broadcast.js
+++ b/lib/internal/streams/iter/broadcast.js
@@ -121,24 +121,26 @@ class BroadcastImpl {
 
   push(...args) {
     const { transforms, options } = parsePullArgs(args);
-    const rawConsumer = this.#createRawConsumer();
+    const signal = options?.signal;
+    if (signal !== undefined) {
+      validateAbortSignal(signal, 'options.signal');
+    }
+    // The raw consumer handles the signal so abort works even when no
+    // transforms are present and pull() is not used.
+    const rawConsumer = this.#createRawConsumer(signal);
 
-    // When transforms are present, delegate to pull() which creates its
-    // own internal AbortController that follows the external signal.
-    // When no transforms, return rawConsumer directly (controller elided
-    // per PULL-02 optimization -- no transforms means no signal recipient).
     if (transforms.length > 0) {
       const pullArgs = [...transforms];
-      if (options?.signal) {
+      if (signal) {
         ArrayPrototypePush(pullArgs,
-                           { __proto__: null, signal: options.signal });
+                           { __proto__: null, signal });
       }
       return pullWithTransforms(rawConsumer, ...pullArgs);
     }
     return rawConsumer;
   }
 
-  #createRawConsumer() {
+  #createRawConsumer(signal) {
     const state = {
       __proto__: null,
       // Start at the oldest buffered entry so late-joining consumers
@@ -147,6 +149,9 @@ class BroadcastImpl {
       resolve: null,
       reject: null,
       detached: false,
+      aborted: false,
+      abortReason: undefined,
+      cleanup: null,
     };
 
     this.#consumers.add(state);
@@ -170,6 +175,22 @@ class BroadcastImpl {
       self.#consumers.delete(state);
       self.#minCursorDirty = true;
       self.#tryTrimBuffer();
+      state.cleanup?.();
+      state.cleanup = null;
+    }
+
+    function abort() {
+      if (state.detached) return;
+      state.aborted = true;
+      state.abortReason = signal.reason;
+      const reject = state.reject;
+      detach();
+      reject?.(state.abortReason);
+    }
+
+    if (signal) {
+      state.cleanup = () => signal.removeEventListener('abort', abort);
+      onSignalAbort(signal, abort);
     }
 
     return {
@@ -179,6 +200,7 @@ class BroadcastImpl {
           __proto__: null,
           next() {
             if (state.detached) {
+              if (state.aborted) return PromiseReject(state.abortReason);
               if (self.#error) return PromiseReject(self.#error);
               return kDone;
             }
@@ -197,8 +219,7 @@ class BroadcastImpl {
             }
 
             if (self.#error) {
-              state.detached = true;
-              self.#consumers.delete(state);
+              detach();
               return PromiseReject(self.#error);
             }
 
@@ -250,6 +271,8 @@ class BroadcastImpl {
         consumer.resolve = null;
         consumer.reject = null;
       }
+      consumer.cleanup?.();
+      consumer.cleanup = null;
       consumer.detached = true;
     }
     this.#consumers.clear();
@@ -320,6 +343,8 @@ class BroadcastImpl {
         consumer.resolve = null;
         consumer.reject = null;
       }
+      consumer.cleanup?.();
+      consumer.cleanup = null;
       consumer.detached = true;
     }
     this.#consumers.clear();

--- a/lib/internal/streams/iter/share.js
+++ b/lib/internal/streams/iter/share.js
@@ -8,8 +8,10 @@
 const {
   ArrayPrototypePush,
   PromisePrototypeThen,
+  PromiseReject,
   PromiseResolve,
   PromiseWithResolvers,
+  SafePromiseRace,
   SafeSet,
   SymbolAsyncIterator,
   SymbolDispose,
@@ -95,7 +97,11 @@ class ShareImpl {
 
   pull(...args) {
     const { transforms, options } = parsePullArgs(args);
-    const rawConsumer = this.#createRawConsumer();
+    const signal = options?.signal;
+    if (signal !== undefined) {
+      validateAbortSignal(signal, 'options.signal');
+    }
+    const rawConsumer = this.#createRawConsumer(signal);
 
     if (transforms.length > 0) {
       if (options) {
@@ -106,13 +112,16 @@ class ShareImpl {
     return rawConsumer;
   }
 
-  #createRawConsumer() {
+  #createRawConsumer(signal) {
     const state = {
       __proto__: null,
       cursor: this.#bufferStart,
       resolve: null,
       reject: null,
       detached: false,
+      aborted: false,
+      abortReason: undefined,
+      cleanup: null,
     };
 
     this.#consumers.add(state);
@@ -126,15 +135,55 @@ class ShareImpl {
     }
     const self = this;
 
+    function detach() {
+      state.detached = true;
+      state.resolve = null;
+      state.reject = null;
+      if (self.#deleteConsumer(state)) {
+        self.#tryTrimBuffer();
+      }
+      state.cleanup?.();
+      state.cleanup = null;
+    }
+
+    function abort() {
+      if (state.detached) return;
+      state.aborted = true;
+      state.abortReason = signal.reason;
+      const reject = state.reject;
+      detach();
+      reject?.(state.abortReason);
+    }
+
+    function waitForAbort(promise) {
+      if (!signal) return promise;
+      if (state.aborted) return PromiseReject(state.abortReason);
+
+      const {
+        promise: abortPromise,
+        reject,
+      } = PromiseWithResolvers();
+      state.reject = reject;
+      return SafePromiseRace([promise, abortPromise]);
+    }
+
+    if (signal) {
+      state.cleanup = () => signal.removeEventListener('abort', abort);
+      onSignalAbort(signal, abort);
+    }
+
     return {
       __proto__: null,
       [SymbolAsyncIterator]() {
         return {
           __proto__: null,
           async next() {
+            if (state.aborted) {
+              throw state.abortReason;
+            }
+
             if (self.#sourceError) {
-              state.detached = true;
-              self.#consumers.delete(state);
+              detach();
               throw self.#sourceError;
             }
 
@@ -144,12 +193,12 @@ class ShareImpl {
             // cursor must re-pull rather than terminating prematurely.
             for (;;) {
               if (state.detached) {
+                if (state.aborted) throw state.abortReason;
                 return { __proto__: null, done: true, value: undefined };
               }
 
               if (self.#cancelled) {
-                state.detached = true;
-                self.#deleteConsumer(state);
+                detach();
                 return { __proto__: null, done: true, value: undefined };
               }
 
@@ -167,42 +216,30 @@ class ShareImpl {
               }
 
               if (self.#sourceExhausted) {
-                state.detached = true;
-                self.#deleteConsumer(state);
+                detach();
                 if (self.#sourceError) throw self.#sourceError;
                 return { __proto__: null, done: true, value: undefined };
               }
 
               // Need to pull from source - check buffer limit
-              const canPull = await self.#waitForBufferSpace();
+              const canPull = await waitForAbort(self.#waitForBufferSpace());
               if (!canPull) {
-                state.detached = true;
-                self.#deleteConsumer(state);
+                detach();
                 if (self.#sourceError) throw self.#sourceError;
                 return { __proto__: null, done: true, value: undefined };
               }
 
-              await self.#pullFromSource();
+              await waitForAbort(self.#pullFromSource());
             }
           },
 
           async return() {
-            state.detached = true;
-            state.resolve = null;
-            state.reject = null;
-            if (self.#deleteConsumer(state)) {
-              self.#tryTrimBuffer();
-            }
+            detach();
             return { __proto__: null, done: true, value: undefined };
           },
 
           async throw() {
-            state.detached = true;
-            state.resolve = null;
-            state.reject = null;
-            if (self.#deleteConsumer(state)) {
-              self.#tryTrimBuffer();
-            }
+            detach();
             return { __proto__: null, done: true, value: undefined };
           },
         };
@@ -223,15 +260,15 @@ class ShareImpl {
     }
 
     for (const consumer of this.#consumers) {
-      if (consumer.resolve) {
-        if (reason !== undefined) {
-          consumer.reject?.(reason);
-        } else {
-          consumer.resolve({ __proto__: null, done: true, value: undefined });
-        }
-        consumer.resolve = null;
-        consumer.reject = null;
+      if (reason !== undefined && consumer.reject) {
+        consumer.reject(reason);
+      } else if (consumer.resolve) {
+        consumer.resolve({ __proto__: null, done: true, value: undefined });
       }
+      consumer.resolve = null;
+      consumer.reject = null;
+      consumer.cleanup?.();
+      consumer.cleanup = null;
       consumer.detached = true;
     }
     this.#consumers.clear();

--- a/test/parallel/test-stream-iter-broadcast-basic.js
+++ b/test/parallel/test-stream-iter-broadcast-basic.js
@@ -243,6 +243,20 @@ async function testLateJoinerSeesBufferedData() {
   assert.strictEqual(result, 'before-join');
 }
 
+async function testConsumerAbortSignal() {
+  const ac = new AbortController();
+  const { broadcast: bc } = broadcast();
+  const consumer = bc.push({ signal: ac.signal });
+  const iterator = consumer[Symbol.asyncIterator]();
+  const next = iterator.next();
+
+  assert.strictEqual(bc.consumerCount, 1);
+  ac.abort(new Error('consumer aborted'));
+
+  await assert.rejects(next, { message: 'consumer aborted' });
+  assert.strictEqual(bc.consumerCount, 0);
+}
+
 Promise.all([
   testBasicBroadcast(),
   testMultipleWrites(),
@@ -257,4 +271,5 @@ Promise.all([
   testFailDetachesConsumers(),
   testWriterFailIdempotent(),
   testLateJoinerSeesBufferedData(),
+  testConsumerAbortSignal(),
 ]).then(common.mustCall());

--- a/test/parallel/test-stream-iter-share-async.js
+++ b/test/parallel/test-stream-iter-share-async.js
@@ -265,6 +265,24 @@ async function testShareStringSource() {
   assert.strictEqual(result, 'hello-share');
 }
 
+async function testShareConsumerAbortSignal() {
+  const ac = new AbortController();
+  async function* never() {
+    await new Promise(() => {});
+    yield [];
+  }
+  const shared = share(never());
+  const consumer = shared.pull({ signal: ac.signal });
+  const iterator = consumer[Symbol.asyncIterator]();
+  const next = iterator.next();
+
+  assert.strictEqual(shared.consumerCount, 1);
+  ac.abort(new Error('consumer aborted'));
+
+  await assert.rejects(next, { message: 'consumer aborted' });
+  assert.strictEqual(shared.consumerCount, 0);
+}
+
 Promise.all([
   testBasicShare(),
   testShareMultipleConsumers(),
@@ -279,4 +297,5 @@ Promise.all([
   testShareConsumerBreak(),
   testShareMultipleConsumersConcurrentPull(),
   testShareStringSource(),
+  testShareConsumerAbortSignal(),
 ]).then(common.mustCall());

--- a/test/parallel/test-stream-iter-validation.js
+++ b/test/parallel/test-stream-iter-validation.js
@@ -146,6 +146,8 @@ assert.throws(() => broadcast({ highWaterMark: Number.MAX_SAFE_INTEGER + 1 }),
 
 assert.throws(() => broadcast({ signal: {} }), { code: 'ERR_INVALID_ARG_TYPE' });
 assert.throws(() => broadcast({ backpressure: 'bad' }), { code: 'ERR_INVALID_ARG_VALUE' });
+assert.throws(() => broadcast().broadcast.push({ signal: {} }),
+              { code: 'ERR_INVALID_ARG_TYPE' });
 
 // Broadcast.from rejects non-iterable input
 assert.throws(() => Broadcast.from(42), { code: 'ERR_INVALID_ARG_TYPE' });
@@ -162,6 +164,8 @@ assert.throws(() => share(from('a'), { highWaterMark: Number.MAX_SAFE_INTEGER + 
               { code: 'ERR_OUT_OF_RANGE' });
 assert.throws(() => share(from('a'), { signal: {} }), { code: 'ERR_INVALID_ARG_TYPE' });
 assert.throws(() => share(from('a'), { backpressure: 'bad' }), { code: 'ERR_INVALID_ARG_VALUE' });
+assert.throws(() => share(from('a')).pull({ signal: {} }),
+              { code: 'ERR_INVALID_ARG_TYPE' });
 
 // share() values < 1 are clamped (no desiredSize, but accepts the value)
 share(from('a'), { highWaterMark: 0 }).cancel();


### PR DESCRIPTION
Wire per-consumer AbortSignal handling into broadcast.push() and share.pull() raw consumers so pending next() calls settle even when no transforms are present.

Add regression tests for the no-transform paths and validation coverage for per-consumer signal options.

Fixes: https://github.com/nodejs/node/issues/63302


Assisted-by: openai:gpt-5.5

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
