### PR TITLE
stream: decode stream/iter text consumers incrementally

### DIFF
--- a/benchmark/streams/iter-consumers-text.js
+++ b/benchmark/streams/iter-consumers-text.js
@@ -1,0 +1,78 @@
+// Throughput benchmark: collect stream/iter sources as text.
+// Measures text() and textSync() consumer overhead for large byte workloads.
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  api: ['async', 'sync'],
+  datasize: [1024 * 1024, 16 * 1024 * 1024, 64 * 1024 * 1024],
+  chunkSize: [64 * 1024],
+  kind: ['ascii', 'multibyte'],
+  n: [5],
+}, {
+  flags: ['--experimental-stream-iter'],
+  test: {
+    chunkSize: 64,
+    datasize: 1024,
+    n: 1,
+  },
+});
+
+const MULTIBYTE_FILL = 'Blåbærsyltetøy';
+
+function createChunks(datasize, chunkSize, kind) {
+  let data;
+  let expectedLength;
+
+  switch (kind) {
+    case 'ascii':
+      data = Buffer.alloc(datasize, 'a');
+      expectedLength = data.length;
+      break;
+    case 'multibyte': {
+      const fillLength = Buffer.byteLength(MULTIBYTE_FILL);
+      const value = MULTIBYTE_FILL.repeat(Math.ceil(datasize / fillLength));
+      data = Buffer.from(value);
+      expectedLength = value.length;
+      break;
+    }
+  }
+
+  const chunks = [];
+  for (let offset = 0; offset < data.length; offset += chunkSize) {
+    chunks.push(data.subarray(offset, offset + chunkSize));
+  }
+
+  return { __proto__: null, chunks, expectedLength, totalBytes: data.length };
+}
+
+async function main({ api, datasize, chunkSize, kind, n }) {
+  const { text, textSync } = require('stream/iter');
+  const { chunks, expectedLength, totalBytes } =
+    createChunks(datasize, chunkSize, kind);
+  const totalOps = (totalBytes * n) / (1024 * 1024);
+
+  switch (api) {
+    case 'async':
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        const result = await text(chunks);
+        if (result.length !== expectedLength) {
+          throw new Error('Invalid decoded text length');
+        }
+      }
+      bench.end(totalOps);
+      break;
+    case 'sync':
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        const result = textSync(chunks);
+        if (result.length !== expectedLength) {
+          throw new Error('Invalid decoded text length');
+        }
+      }
+      bench.end(totalOps);
+      break;
+  }
+}

--- a/lib/internal/streams/iter/consumers.js
+++ b/lib/internal/streams/iter/consumers.js
@@ -211,6 +211,8 @@ function validateSyncConsumerOptions(options) {
 // =============================================================================
 
 const kNullPrototype = { __proto__: null };
+const kDecoderOptions = { __proto__: null, fatal: true };
+const kDecoderStreamOptions = { __proto__: null, stream: true };
 
 /**
  * Collect all bytes from a sync source.
@@ -231,12 +233,38 @@ function bytesSync(source, options = kNullPrototype) {
  */
 function textSync(source, options = kNullPrototype) {
   validateSyncConsumerOptions(options);
-  const data = concatBytes(collectSync(source, options.limit));
-  const decoder = new TextDecoder(options.encoding ?? 'utf-8', {
-    __proto__: null,
-    fatal: true,
-  });
-  return decoder.decode(data);
+  const normalized = fromSync(source);
+  const decoder = new TextDecoder(options.encoding ?? 'utf-8',
+                                  kDecoderOptions);
+  let result = '';
+  let decoderError;
+  let totalBytes = 0;
+
+  for (const batch of normalized) {
+    for (let i = 0; i < batch.length; i++) {
+      const chunk = batch[i];
+      if (options.limit !== undefined) {
+        totalBytes += TypedArrayPrototypeGetByteLength(chunk);
+        if (totalBytes > options.limit) {
+          throw new ERR_OUT_OF_RANGE('totalBytes', `<= ${options.limit}`,
+                                     totalBytes);
+        }
+      }
+
+      if (decoderError === undefined) {
+        try {
+          result += decoder.decode(chunk, kDecoderStreamOptions);
+        } catch (error) {
+          decoderError = error;
+        }
+      }
+    }
+  }
+
+  if (decoderError !== undefined) {
+    throw decoderError;
+  }
+  return result + decoder.decode();
 }
 
 /**
@@ -285,13 +313,41 @@ async function bytes(source, options = kNullPrototype) {
  */
 async function text(source, options = kNullPrototype) {
   validateConsumerOptions(options);
-  const chunks = await collectAsync(source, options.signal, options.limit);
-  const data = concatBytes(chunks);
-  const decoder = new TextDecoder(options.encoding ?? 'utf-8', {
-    __proto__: null,
-    fatal: true,
-  });
-  return decoder.decode(data);
+  options.signal?.throwIfAborted();
+
+  const normalized = from(source);
+  const decoder = new TextDecoder(options.encoding ?? 'utf-8',
+                                  kDecoderOptions);
+  let result = '';
+  let decoderError;
+  let totalBytes = 0;
+
+  for await (const batch of normalized) {
+    options.signal?.throwIfAborted();
+    for (let i = 0; i < batch.length; i++) {
+      const chunk = batch[i];
+      if (options.limit !== undefined) {
+        totalBytes += TypedArrayPrototypeGetByteLength(chunk);
+        if (totalBytes > options.limit) {
+          throw new ERR_OUT_OF_RANGE('totalBytes', `<= ${options.limit}`,
+                                     totalBytes);
+        }
+      }
+
+      if (decoderError === undefined) {
+        try {
+          result += decoder.decode(chunk, kDecoderStreamOptions);
+        } catch (error) {
+          decoderError = error;
+        }
+      }
+    }
+  }
+
+  if (decoderError !== undefined) {
+    throw decoderError;
+  }
+  return result + decoder.decode();
 }
 
 /**

--- a/test/parallel/test-stream-iter-consumers-text.js
+++ b/test/parallel/test-stream-iter-consumers-text.js
@@ -116,6 +116,61 @@ async function testTextMultiChunkSplitCodepoint() {
   assert.strictEqual(result, '€');
 }
 
+function testTextSyncMultiChunkSplitCodepoint() {
+  function* splitSource() {
+    yield [new Uint8Array([0xE2, 0x82])];
+    yield [new Uint8Array([0xAC])];
+  }
+  const result = textSync(splitSource());
+  assert.strictEqual(result, '€');
+}
+
+async function testTextIncompleteFinalCodepoint() {
+  async function* incompleteSource() {
+    yield [new Uint8Array([0xE2, 0x82])];
+  }
+
+  await assert.rejects(
+    () => text(incompleteSource()),
+    { name: 'TypeError' },
+  );
+}
+
+function testTextSyncIncompleteFinalCodepoint() {
+  function* incompleteSource() {
+    yield [new Uint8Array([0xE2, 0x82])];
+  }
+
+  assert.throws(
+    () => textSync(incompleteSource()),
+    { name: 'TypeError' },
+  );
+}
+
+async function testTextLimitPrecedesDecodeError() {
+  async function* invalidThenTooLargeSource() {
+    yield [new Uint8Array([0xFF])];
+    yield [new Uint8Array([0x61, 0x62])];
+  }
+
+  await assert.rejects(
+    () => text(invalidThenTooLargeSource(), { limit: 1 }),
+    { code: 'ERR_OUT_OF_RANGE' },
+  );
+}
+
+function testTextSyncLimitPrecedesDecodeError() {
+  function* invalidThenTooLargeSource() {
+    yield [new Uint8Array([0xFF])];
+    yield [new Uint8Array([0x61, 0x62])];
+  }
+
+  assert.throws(
+    () => textSync(invalidThenTooLargeSource(), { limit: 1 }),
+    { code: 'ERR_OUT_OF_RANGE' },
+  );
+}
+
 // BOM should be stripped (ignoreBOM defaults to false per spec)
 async function testTextBOMStripped() {
   // UTF-8 BOM: 0xEF, 0xBB, 0xBF followed by 'hi'
@@ -157,6 +212,11 @@ Promise.all([
   testTextEmpty(),
   testTextWithSignal(),
   testTextMultiChunkSplitCodepoint(),
+  testTextSyncMultiChunkSplitCodepoint(),
+  testTextIncompleteFinalCodepoint(),
+  testTextSyncIncompleteFinalCodepoint(),
+  testTextLimitPrecedesDecodeError(),
+  testTextSyncLimitPrecedesDecodeError(),
   testTextBOMStripped(),
   testTextSyncBOMStripped(),
   testTextUnsupportedEncodingThrowsRangeError(),


### PR DESCRIPTION
```
                                                                                                    confidence improvement accuracy (*)    (**)   (***)
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=1048576 datasize=1048576 api='async'             ***     20.20 %       ±3.62%  ±4.82%  ±6.28%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=1048576 datasize=1048576 api='sync'              ***     18.11 %       ±3.81%  ±5.06%  ±6.59%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=1048576 datasize=16777216 api='async'              *      6.11 %       ±5.26%  ±7.01%  ±9.14%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=1048576 datasize=16777216 api='sync'              **      5.16 %       ±3.46%  ±4.60%  ±5.99%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=1048576 datasize=67108864 api='async'                     0.25 %       ±2.48%  ±3.30%  ±4.29%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=1048576 datasize=67108864 api='sync'                     -0.79 %       ±3.28%  ±4.36%  ±5.68%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=4096 datasize=1048576 api='async'                ***      8.79 %       ±4.20%  ±5.61%  ±7.34%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=4096 datasize=1048576 api='sync'                 ***      9.04 %       ±3.98%  ±5.30%  ±6.89%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=4096 datasize=16777216 api='async'                       -0.82 %       ±4.22%  ±5.66%  ±7.44%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=4096 datasize=16777216 api='sync'                ***    -10.42 %       ±2.13%  ±2.83%  ±3.68%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=4096 datasize=67108864 api='async'                        3.02 %       ±3.91%  ±5.25%  ±6.93%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=4096 datasize=67108864 api='sync'                         1.66 %       ±3.46%  ±4.61%  ±6.00%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=65536 datasize=1048576 api='async'               ***     15.09 %       ±7.51% ±10.04% ±13.18%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=65536 datasize=1048576 api='sync'                         1.19 %       ±6.51%  ±8.69% ±11.36%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=65536 datasize=16777216 api='async'                       1.00 %       ±2.06%  ±2.74%  ±3.59%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=65536 datasize=16777216 api='sync'               ***      7.71 %       ±3.14%  ±4.20%  ±5.51%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=65536 datasize=67108864 api='async'                *     -4.19 %       ±3.59%  ±4.80%  ±6.30%
streams/iter-consumers-text.js n=5 kind='ascii' chunkSize=65536 datasize=67108864 api='sync'               ***     -6.64 %       ±2.77%  ±3.70%  ±4.85%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=1048576 datasize=1048576 api='async'         ***      8.98 %       ±4.80%  ±6.43%  ±8.48%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=1048576 datasize=1048576 api='sync'           **      4.69 %       ±2.79%  ±3.72%  ±4.84%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=1048576 datasize=16777216 api='async'                 1.58 %       ±1.69%  ±2.26%  ±2.95%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=1048576 datasize=16777216 api='sync'                  2.04 %       ±2.11%  ±2.84%  ±3.75%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=1048576 datasize=67108864 api='async'                 0.06 %       ±2.35%  ±3.13%  ±4.09%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=1048576 datasize=67108864 api='sync'                  0.15 %       ±2.12%  ±2.82%  ±3.67%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=4096 datasize=1048576 api='async'            ***      5.45 %       ±2.63%  ±3.52%  ±4.61%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=4096 datasize=1048576 api='sync'               *      3.09 %       ±3.06%  ±4.09%  ±5.36%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=4096 datasize=16777216 api='async'           ***      9.36 %       ±3.81%  ±5.13%  ±6.78%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=4096 datasize=16777216 api='sync'                    -1.21 %       ±3.14%  ±4.22%  ±5.59%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=4096 datasize=67108864 api='async'                    0.15 %       ±2.08%  ±2.77%  ±3.63%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=4096 datasize=67108864 api='sync'                     0.17 %       ±0.95%  ±1.27%  ±1.66%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=65536 datasize=1048576 api='async'           ***      3.89 %       ±2.08%  ±2.77%  ±3.60%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=65536 datasize=1048576 api='sync'              *      1.80 %       ±1.80%  ±2.40%  ±3.12%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=65536 datasize=16777216 api='async'                  -2.65 %       ±2.68%  ±3.58%  ±4.69%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=65536 datasize=16777216 api='sync'                   -0.54 %       ±1.22%  ±1.63%  ±2.13%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=65536 datasize=67108864 api='async'          ***     -2.77 %       ±0.94%  ±1.25%  ±1.64%
streams/iter-consumers-text.js n=5 kind='multibyte' chunkSize=65536 datasize=67108864 api='sync'            **     -3.73 %       ±2.18%  ±2.92%  ±3.84%
```