### PR TITLE
stream: avoid double buffering in composed streams

### DIFF
--- a/benchmark/streams/compose-backpressure.js
+++ b/benchmark/streams/compose-backpressure.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const common = require('../common');
+
+const {
+  Duplex,
+  PassThrough,
+  Readable,
+  Transform,
+  Writable,
+  compose,
+} = require('node:stream');
+
+const bench = common.createBenchmark(main, {
+  n: [1e5],
+  api: ['compose', 'duplex-from'],
+  side: ['readable', 'writable'],
+  sync: ['yes', 'no'],
+  len: [1024],
+}, {
+  combinationFilter({ side, sync }) {
+    return side === 'writable' || sync === 'yes';
+  },
+});
+
+function main({ n, api, side, sync, len }) {
+  if (side === 'readable') {
+    runReadable({ n, api, len });
+  } else {
+    runWritable({ n, api, sync, len });
+  }
+}
+
+function runReadable({ n, api, len }) {
+  const chunk = Buffer.allocUnsafe(len);
+  let remaining = n;
+  const readable = new Readable({
+    read() {
+      if (remaining-- > 0) {
+        this.push(chunk);
+      } else {
+        this.push(null);
+      }
+    },
+  });
+  const stream = api === 'compose' ?
+    compose(readable, new PassThrough()) :
+    Duplex.from({ readable });
+  let read = 0;
+
+  bench.start();
+  stream.on('data', () => {
+    read++;
+  });
+  stream.on('end', () => {
+    bench.end(read);
+  });
+}
+
+function runWritable({ n, api, sync, len }) {
+  const chunk = Buffer.allocUnsafe(len);
+  const async = sync === 'no';
+  const writable = new Writable({
+    highWaterMark: 1,
+    write(chunk, encoding, callback) {
+      if (async) {
+        process.nextTick(callback);
+      } else {
+        callback();
+      }
+    },
+  });
+  const stream = api === 'compose' ?
+    compose(new Transform({
+      transform(chunk, encoding, callback) {
+        callback(null, chunk);
+      },
+    }), writable) :
+    Duplex.from({ writable });
+  let written = 0;
+
+  bench.start();
+  write();
+
+  function write() {
+    while (written < n) {
+      written++;
+      if (!stream.write(chunk)) {
+        stream.once('drain', write);
+        return;
+      }
+    }
+    stream.end();
+  }
+
+  stream.on('finish', () => {
+    bench.end(written);
+  });
+}

--- a/lib/internal/streams/compose.js
+++ b/lib/internal/streams/compose.js
@@ -113,13 +113,11 @@ module.exports = function compose(...streams) {
     isTransformStream(tail)
   );
 
-  // TODO(ronag): Avoid double buffering.
-  // Implement Writable/Readable/Duplex traits.
-  // See, https://github.com/nodejs/node/pull/33515.
   d = new Duplex({
-    // TODO (ronag): highWaterMark?
     writableObjectMode: !!head?.writableObjectMode,
     readableObjectMode: !!tail?.readableObjectMode,
+    writableHighWaterMark: 0,
+    readableHighWaterMark: 0,
     writable,
     readable,
   });

--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -280,13 +280,11 @@ function _duplexify(pair) {
     }
   }
 
-  // TODO(ronag): Avoid double buffering.
-  // Implement Writable/Readable/Duplex traits.
-  // See, https://github.com/nodejs/node/pull/33515.
   d = new Duplexify({
-    // TODO (ronag): highWaterMark?
     readableObjectMode: !!r?.readableObjectMode,
     writableObjectMode: !!w?.writableObjectMode,
+    readableHighWaterMark: 0,
+    writableHighWaterMark: 0,
     readable,
     writable,
   });

--- a/test/parallel/test-stream-compose.js
+++ b/test/parallel/test-stream-compose.js
@@ -537,3 +537,27 @@ const assert = require('assert');
   assert.strictEqual(duplex.destroyed, true);
 
 }
+
+// Write-side backpressure should be reported by the composed wrapper as soon as
+// the underlying head stream reports it.
+{
+  const pending = [];
+  const head = new Transform({
+    writableHighWaterMark: 1,
+    transform(chunk, encoding, callback) {
+      pending.push(callback);
+    },
+  });
+  const tail = new Writable({
+    write(chunk, encoding, callback) {
+      callback();
+    },
+  });
+  const composed = compose(head, tail);
+
+  assert.strictEqual(composed.writableHighWaterMark, 0);
+  assert.strictEqual(composed.write(Buffer.alloc(2), common.mustCall()), false);
+  process.nextTick(() => pending.shift()(null, Buffer.alloc(2)));
+  composed.end();
+  composed.on('finish', common.mustCall());
+}

--- a/test/parallel/test-stream-duplex-from.js
+++ b/test/parallel/test-stream-duplex-from.js
@@ -418,3 +418,44 @@ function makeATestWritableStream(writeFunc) {
   }));
   r.destroy(expectedErr);
 }
+
+// Avoid buffering readable data both in the wrapper Duplex and the underlying
+// readable stream.
+{
+  const chunks = Array.from({ length: 10 }, (_, n) => n);
+  const r = new Readable({
+    objectMode: true,
+    read() {
+      while (chunks.length > 0) {
+        this.push(chunks.shift());
+      }
+      this.push(null);
+    },
+  });
+  const d = Duplex.from({ readable: r });
+
+  d.read(0);
+  assert.strictEqual(d.readableHighWaterMark, 0);
+  assert.strictEqual(d.readableLength, 1);
+
+  d.resume();
+}
+
+// Write-side backpressure should be reported by the wrapper as soon as the
+// underlying writable reports it.
+{
+  const pending = [];
+  const w = new Writable({
+    highWaterMark: 1,
+    write(chunk, encoding, callback) {
+      pending.push(callback);
+    },
+  });
+  const d = Duplex.from({ writable: w });
+
+  assert.strictEqual(d.writableHighWaterMark, 0);
+  assert.strictEqual(d.write(Buffer.alloc(2), common.mustCall()), false);
+  process.nextTick(() => pending.shift()());
+  d.end();
+  d.on('finish', common.mustCall());
+}


### PR DESCRIPTION
```console
                                                                                               confidence improvement accuracy (*)   (**)  (***)
streams/compose-backpressure.js len=1024 sync='no' side='writable' api='compose' n=100000             ***      7.24 %       ±2.68% ±3.59% ±4.73%
streams/compose-backpressure.js len=1024 sync='no' side='writable' api='duplex-from' n=100000         ***     -9.33 %       ±1.68% ±2.23% ±2.91%
streams/compose-backpressure.js len=1024 sync='yes' side='readable' api='compose' n=100000                    -2.28 %       ±4.12% ±5.54% ±7.32%
streams/compose-backpressure.js len=1024 sync='yes' side='readable' api='duplex-from' n=100000        ***    -79.41 %       ±1.04% ±1.40% ±1.86%
streams/compose-backpressure.js len=1024 sync='yes' side='writable' api='compose' n=100000                    -0.03 %       ±0.88% ±1.17% ±1.53%
streams/compose-backpressure.js len=1024 sync='yes' side='writable' api='duplex-from' n=100000                -1.26 %       ±1.71% ±2.27% ±2.96%
```