### PR TITLE
stream: reduce writable buffered write allocations

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2298,7 +2298,7 @@ class Http2Stream extends Duplex {
     process.nextTick(() => {
       if (writeCallbackErr ||
         !this._writableState.ending ||
-        this._writableState.buffered.length ||
+        this._writableState.bufferedRequestCount ||
         (this[kState].flags & STREAM_FLAGS_HAS_TRAILERS))
         return endCheckCallback();
       debugStreamObj(this, 'shutting down writable on last write');

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -26,7 +26,6 @@
 'use strict';
 
 const {
-  ArrayPrototypeSlice,
   Error,
   FunctionPrototypeSymbolHasInstance,
   ObjectDefineProperties,
@@ -97,6 +96,8 @@ const kDefaultEncodingValue = Symbol('kDefaultEncodingValue');
 const kWriteCbValue = Symbol('kWriteCbValue');
 const kAfterWriteTickInfoValue = Symbol('kAfterWriteTickInfoValue');
 const kBufferedValue = Symbol('kBufferedValue');
+const kBufferedEncodingsValue = Symbol('kBufferedEncodingsValue');
+const kBufferedCallbacksValue = Symbol('kBufferedCallbacksValue');
 
 const kSync = 1 << 9;
 const kFinalCalled = 1 << 10;
@@ -285,12 +286,27 @@ ObjectDefineProperties(WritableState.prototype, {
   buffered: {
     __proto__: null,
     enumerable: false,
-    get() { return (this[kState] & kBuffered) !== 0 ? this[kBufferedValue] : []; },
+    get() { return this.getBuffer(); },
     set(value) {
-      this[kBufferedValue] = value;
       if (value) {
         this[kState] |= kBuffered;
+        const length = value.length;
+        const chunks = new Array(length);
+        const encodings = new Array(length);
+        const callbacks = new Array(length);
+        for (let i = 0; i < length; ++i) {
+          const entry = value[i];
+          chunks[i] = entry.chunk;
+          encodings[i] = entry.encoding;
+          callbacks[i] = entry.callback;
+        }
+        this[kBufferedValue] = chunks;
+        this[kBufferedEncodingsValue] = encodings;
+        this[kBufferedCallbacksValue] = callbacks;
       } else {
+        this[kBufferedValue] = null;
+        this[kBufferedEncodingsValue] = null;
+        this[kBufferedCallbacksValue] = null;
         this[kState] &= ~kBuffered;
       }
     },
@@ -360,13 +376,29 @@ function WritableState(options, stream, isDuplex) {
 
 function resetBuffer(state) {
   state[kBufferedValue] = null;
+  state[kBufferedEncodingsValue] = null;
+  state[kBufferedCallbacksValue] = null;
   state.bufferedIndex = 0;
   state[kState] |= kAllBuffers | kAllNoop;
   state[kState] &= ~kBuffered;
 }
 
 WritableState.prototype.getBuffer = function getBuffer() {
-  return (this[kState] & kBuffered) === 0 ? [] : ArrayPrototypeSlice(this.buffered, this.bufferedIndex);
+  if ((this[kState] & kBuffered) === 0)
+    return [];
+
+  const chunks = this[kBufferedValue];
+  const encodings = this[kBufferedEncodingsValue];
+  const callbacks = this[kBufferedCallbacksValue];
+  const buffer = new Array(chunks.length - this.bufferedIndex);
+  for (let i = this.bufferedIndex, n = 0; i < chunks.length; ++i, ++n) {
+    buffer[n] = {
+      chunk: chunks[i],
+      encoding: encodings[i],
+      callback: callbacks[i],
+    };
+  }
+  return buffer;
 };
 
 ObjectDefineProperty(WritableState.prototype, 'bufferedRequestCount', {
@@ -554,9 +586,13 @@ function writeOrBuffer(stream, state, chunk, encoding, callback) {
     if ((state[kState] & kBuffered) === 0) {
       state[kState] |= kBuffered;
       state[kBufferedValue] = [];
+      state[kBufferedEncodingsValue] = [];
+      state[kBufferedCallbacksValue] = [];
     }
 
-    state[kBufferedValue].push({ chunk, encoding, callback });
+    state[kBufferedValue].push(chunk);
+    state[kBufferedEncodingsValue].push(encoding);
+    state[kBufferedCallbacksValue].push(callback);
     if ((state[kState] & kAllBuffers) !== 0 && encoding !== 'buffer') {
       state[kState] &= ~kAllBuffers;
     }
@@ -726,8 +762,11 @@ function errorBuffer(state) {
   }
 
   if ((state[kState] & kBuffered) !== 0) {
-    for (let n = state.bufferedIndex; n < state.buffered.length; ++n) {
-      const { chunk, callback } = state[kBufferedValue][n];
+    const chunks = state[kBufferedValue];
+    const callbacks = state[kBufferedCallbacksValue];
+    for (let n = state.bufferedIndex; n < chunks.length; ++n) {
+      const chunk = chunks[n];
+      const callback = callbacks[n];
       const len = (state[kState] & kObjectMode) !== 0 ? 1 : chunk.length;
       state.length -= len;
       callback(state.errored ?? new ERR_STREAM_DESTROYED('write'));
@@ -748,7 +787,12 @@ function clearBuffer(stream, state) {
   }
 
   const objectMode = (state[kState] & kObjectMode) !== 0;
-  const { [kBufferedValue]: buffered, bufferedIndex } = state;
+  const {
+    [kBufferedValue]: buffered,
+    [kBufferedEncodingsValue]: encodings,
+    [kBufferedCallbacksValue]: callbacks,
+    bufferedIndex,
+  } = state;
   const bufferedLength = buffered.length - bufferedIndex;
 
   if (!bufferedLength) {
@@ -763,13 +807,16 @@ function clearBuffer(stream, state) {
 
     const callback = (state[kState] & kAllNoop) !== 0 ? nop : (err) => {
       for (let n = i; n < buffered.length; ++n) {
-        buffered[n].callback(err);
+        callbacks[n](err);
       }
     };
-    // Make a copy of `buffered` if it's going to be used by `callback` above,
-    // since `doWrite` will mutate the array.
-    const chunks = (state[kState] & kAllNoop) !== 0 && i === 0 ?
-      buffered : ArrayPrototypeSlice(buffered, i);
+    const chunks = new Array(bufferedLength);
+    for (let n = i, j = 0; n < buffered.length; ++n, ++j) {
+      chunks[j] = {
+        chunk: buffered[n],
+        encoding: encodings[n],
+      };
+    }
     chunks.allBuffers = (state[kState] & kAllBuffers) !== 0;
 
     doWrite(stream, state, true, state.length, chunks, '', callback);
@@ -777,8 +824,13 @@ function clearBuffer(stream, state) {
     resetBuffer(state);
   } else {
     do {
-      const { chunk, encoding, callback } = buffered[i];
-      buffered[i++] = null;
+      const chunk = buffered[i];
+      const encoding = encodings[i];
+      const callback = callbacks[i];
+      buffered[i] = null;
+      encodings[i] = null;
+      callbacks[i] = null;
+      i++;
       const len = objectMode ? 1 : chunk.length;
       doWrite(stream, state, false, len, chunk, encoding, callback);
     } while (i < buffered.length && (state[kState] & kWriting) === 0);
@@ -787,6 +839,8 @@ function clearBuffer(stream, state) {
       resetBuffer(state);
     } else if (i > 256) {
       buffered.splice(0, i);
+      encodings.splice(0, i);
+      callbacks.splice(0, i);
       state.bufferedIndex = 0;
     } else {
       state.bufferedIndex = i;


### PR DESCRIPTION
```console
                                                                                         confidence improvement accuracy (*)   (**)  (***)
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='no' n=100000                    -0.46 %       ±2.51% ±3.35% ±4.36%
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='yes' n=100000                    0.53 %       ±3.25% ±4.32% ±5.62%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='no' n=100000           ***     -6.06 %       ±1.78% ±2.37% ±3.09%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='yes' n=100000                  -0.47 %       ±2.54% ±3.38% ±4.40%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='no' n=100000                   -0.41 %       ±1.40% ±1.86% ±2.43%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='yes' n=100000                  -0.67 %       ±2.03% ±2.70% ±3.52%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='no' n=100000          ***     -3.98 %       ±2.07% ±2.76% ±3.62%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='yes' n=100000                  1.29 %       ±5.37% ±7.16% ±9.35%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='no' n=100000                    1.08 %       ±1.44% ±1.92% ±2.50%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='yes' n=100000                   1.52 %       ±2.79% ±3.72% ±4.86%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='no' n=100000                  -1.02 %       ±4.28% ±5.75% ±7.60%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='yes' n=100000                  1.43 %       ±3.18% ±4.23% ±5.51%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='no' n=100000                  -0.16 %       ±1.56% ±2.07% ±2.70%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='yes' n=100000                  1.60 %       ±2.29% ±3.05% ±3.99%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='no' n=100000                 -2.12 %       ±5.05% ±6.79% ±8.98%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='yes' n=100000                 0.14 %       ±2.56% ±3.41% ±4.44%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 16 comparisons, you can thus
expect the following amount of false-positive results:
  0.80 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.16 false positives, when considering a   1% risk acceptance (**, ***),
  0.02 false positives, when considering a 0.1% risk acceptance (***)
```