### PR TITLE
stream: reduce buffered write allocations

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2298,7 +2298,7 @@ class Http2Stream extends Duplex {
     process.nextTick(() => {
       if (writeCallbackErr ||
         !this._writableState.ending ||
-        this._writableState.buffered.length ||
+        this._writableState.bufferedRequestCount ||
         (this[kState].flags & STREAM_FLAGS_HAS_TRAILERS))
         return endCheckCallback();
       debugStreamObj(this, 'shutting down writable on last write');

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -97,6 +97,9 @@ const kDefaultEncodingValue = Symbol('kDefaultEncodingValue');
 const kWriteCbValue = Symbol('kWriteCbValue');
 const kAfterWriteTickInfoValue = Symbol('kAfterWriteTickInfoValue');
 const kBufferedValue = Symbol('kBufferedValue');
+const kBufferedEncodingsValue = Symbol('kBufferedEncodingsValue');
+const kBufferedCallbacksValue = Symbol('kBufferedCallbacksValue');
+const kBufferedObjectsValue = Symbol('kBufferedObjectsValue');
 
 const kSync = 1 << 9;
 const kFinalCalled = 1 << 10;
@@ -285,12 +288,29 @@ ObjectDefineProperties(WritableState.prototype, {
   buffered: {
     __proto__: null,
     enumerable: false,
-    get() { return (this[kState] & kBuffered) !== 0 ? this[kBufferedValue] : []; },
+    get() { return this.getBuffer(); },
     set(value) {
-      this[kBufferedValue] = value;
       if (value) {
         this[kState] |= kBuffered;
+        const length = value.length;
+        const chunks = new Array(length);
+        const encodings = new Array(length);
+        const callbacks = new Array(length);
+        for (let i = 0; i < length; ++i) {
+          const entry = value[i];
+          chunks[i] = entry.chunk;
+          encodings[i] = entry.encoding;
+          callbacks[i] = entry.callback;
+        }
+        this[kBufferedValue] = chunks;
+        this[kBufferedEncodingsValue] = encodings;
+        this[kBufferedCallbacksValue] = callbacks;
+        this[kBufferedObjectsValue] = false;
       } else {
+        this[kBufferedValue] = null;
+        this[kBufferedEncodingsValue] = null;
+        this[kBufferedCallbacksValue] = null;
+        this[kBufferedObjectsValue] = false;
         this[kState] &= ~kBuffered;
       }
     },
@@ -360,13 +380,33 @@ function WritableState(options, stream, isDuplex) {
 
 function resetBuffer(state) {
   state[kBufferedValue] = null;
+  state[kBufferedEncodingsValue] = null;
+  state[kBufferedCallbacksValue] = null;
+  state[kBufferedObjectsValue] = false;
   state.bufferedIndex = 0;
   state[kState] |= kAllBuffers | kAllNoop;
   state[kState] &= ~kBuffered;
 }
 
 WritableState.prototype.getBuffer = function getBuffer() {
-  return (this[kState] & kBuffered) === 0 ? [] : ArrayPrototypeSlice(this.buffered, this.bufferedIndex);
+  if ((this[kState] & kBuffered) === 0)
+    return [];
+
+  const chunks = this[kBufferedValue];
+  if (this[kBufferedObjectsValue])
+    return ArrayPrototypeSlice(chunks, this.bufferedIndex);
+
+  const encodings = this[kBufferedEncodingsValue];
+  const callbacks = this[kBufferedCallbacksValue];
+  const buffer = new Array(chunks.length - this.bufferedIndex);
+  for (let i = this.bufferedIndex, n = 0; i < chunks.length; ++i, ++n) {
+    buffer[n] = {
+      chunk: chunks[i],
+      encoding: encodings[i],
+      callback: callbacks[i],
+    };
+  }
+  return buffer;
 };
 
 ObjectDefineProperty(WritableState.prototype, 'bufferedRequestCount', {
@@ -554,9 +594,21 @@ function writeOrBuffer(stream, state, chunk, encoding, callback) {
     if ((state[kState] & kBuffered) === 0) {
       state[kState] |= kBuffered;
       state[kBufferedValue] = [];
+      if (stream._writev) {
+        state[kBufferedObjectsValue] = true;
+      } else {
+        state[kBufferedEncodingsValue] = [];
+        state[kBufferedCallbacksValue] = [];
+      }
     }
 
-    state[kBufferedValue].push({ chunk, encoding, callback });
+    if (state[kBufferedObjectsValue]) {
+      state[kBufferedValue].push({ chunk, encoding, callback });
+    } else {
+      state[kBufferedValue].push(chunk);
+      state[kBufferedEncodingsValue].push(encoding);
+      state[kBufferedCallbacksValue].push(callback);
+    }
     if ((state[kState] & kAllBuffers) !== 0 && encoding !== 'buffer') {
       state[kState] &= ~kAllBuffers;
     }
@@ -726,11 +778,23 @@ function errorBuffer(state) {
   }
 
   if ((state[kState] & kBuffered) !== 0) {
-    for (let n = state.bufferedIndex; n < state.buffered.length; ++n) {
-      const { chunk, callback } = state[kBufferedValue][n];
-      const len = (state[kState] & kObjectMode) !== 0 ? 1 : chunk.length;
-      state.length -= len;
-      callback(state.errored ?? new ERR_STREAM_DESTROYED('write'));
+    const chunks = state[kBufferedValue];
+    if (state[kBufferedObjectsValue]) {
+      for (let n = state.bufferedIndex; n < chunks.length; ++n) {
+        const { chunk, callback } = chunks[n];
+        const len = (state[kState] & kObjectMode) !== 0 ? 1 : chunk.length;
+        state.length -= len;
+        callback(state.errored ?? new ERR_STREAM_DESTROYED('write'));
+      }
+    } else {
+      const callbacks = state[kBufferedCallbacksValue];
+      for (let n = state.bufferedIndex; n < chunks.length; ++n) {
+        const chunk = chunks[n];
+        const callback = callbacks[n];
+        const len = (state[kState] & kObjectMode) !== 0 ? 1 : chunk.length;
+        state.length -= len;
+        callback(state.errored ?? new ERR_STREAM_DESTROYED('write'));
+      }
     }
   }
 
@@ -748,7 +812,13 @@ function clearBuffer(stream, state) {
   }
 
   const objectMode = (state[kState] & kObjectMode) !== 0;
-  const { [kBufferedValue]: buffered, bufferedIndex } = state;
+  const {
+    [kBufferedValue]: buffered,
+    [kBufferedEncodingsValue]: encodings,
+    [kBufferedCallbacksValue]: callbacks,
+    [kBufferedObjectsValue]: bufferedObjects,
+    bufferedIndex,
+  } = state;
   const bufferedLength = buffered.length - bufferedIndex;
 
   if (!bufferedLength) {
@@ -763,13 +833,28 @@ function clearBuffer(stream, state) {
 
     const callback = (state[kState] & kAllNoop) !== 0 ? nop : (err) => {
       for (let n = i; n < buffered.length; ++n) {
-        buffered[n].callback(err);
+        if (bufferedObjects) {
+          buffered[n].callback(err);
+        } else {
+          callbacks[n](err);
+        }
       }
     };
-    // Make a copy of `buffered` if it's going to be used by `callback` above,
-    // since `doWrite` will mutate the array.
-    const chunks = (state[kState] & kAllNoop) !== 0 && i === 0 ?
-      buffered : ArrayPrototypeSlice(buffered, i);
+    let chunks;
+    if (bufferedObjects) {
+      // Make a copy of `buffered` if it's going to be used by `callback`
+      // above, since `doWrite` will mutate the array.
+      chunks = (state[kState] & kAllNoop) !== 0 && i === 0 ?
+        buffered : ArrayPrototypeSlice(buffered, i);
+    } else {
+      chunks = new Array(bufferedLength);
+      for (let n = i, j = 0; n < buffered.length; ++n, ++j) {
+        chunks[j] = {
+          chunk: buffered[n],
+          encoding: encodings[n],
+        };
+      }
+    }
     chunks.allBuffers = (state[kState] & kAllBuffers) !== 0;
 
     doWrite(stream, state, true, state.length, chunks, '', callback);
@@ -777,8 +862,15 @@ function clearBuffer(stream, state) {
     resetBuffer(state);
   } else {
     do {
-      const { chunk, encoding, callback } = buffered[i];
-      buffered[i++] = null;
+      const chunk = bufferedObjects ? buffered[i].chunk : buffered[i];
+      const encoding = bufferedObjects ? buffered[i].encoding : encodings[i];
+      const callback = bufferedObjects ? buffered[i].callback : callbacks[i];
+      buffered[i] = null;
+      if (!bufferedObjects) {
+        encodings[i] = null;
+        callbacks[i] = null;
+      }
+      i++;
       const len = objectMode ? 1 : chunk.length;
       doWrite(stream, state, false, len, chunk, encoding, callback);
     } while (i < buffered.length && (state[kState] & kWriting) === 0);
@@ -787,6 +879,10 @@ function clearBuffer(stream, state) {
       resetBuffer(state);
     } else if (i > 256) {
       buffered.splice(0, i);
+      if (!bufferedObjects) {
+        encodings.splice(0, i);
+        callbacks.splice(0, i);
+      }
       state.bufferedIndex = 0;
     } else {
       state.bufferedIndex = i;


### PR DESCRIPTION
```console
                                                                                         confidence improvement accuracy (*)   (**)  (***)
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='no' n=100000              *     -2.25 %       ±2.03% ±2.71% ±3.55%
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='yes' n=100000                   -1.30 %       ±2.45% ±3.26% ±4.25%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='no' n=100000                    0.49 %       ±1.85% ±2.46% ±3.20%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='yes' n=100000            *     -2.27 %       ±2.09% ±2.79% ±3.66%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='no' n=100000                   -3.12 %       ±4.68% ±6.28% ±8.30%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='yes' n=100000                  -1.80 %       ±2.91% ±3.87% ±5.06%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='no' n=100000                   0.68 %       ±2.62% ±3.48% ±4.53%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='yes' n=100000                  0.52 %       ±5.72% ±7.62% ±9.94%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='no' n=100000                    2.78 %       ±4.77% ±6.40% ±8.43%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='yes' n=100000                   0.35 %       ±4.85% ±6.47% ±8.45%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='no' n=100000                  -0.84 %       ±1.95% ±2.60% ±3.38%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='yes' n=100000                  2.00 %       ±5.57% ±7.44% ±9.74%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='no' n=100000                   0.21 %       ±1.90% ±2.53% ±3.29%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='yes' n=100000                 -1.60 %       ±2.38% ±3.17% ±4.13%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='no' n=100000                  1.62 %       ±2.08% ±2.76% ±3.60%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='yes' n=100000                 1.88 %       ±4.42% ±5.88% ±7.65%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 16 comparisons, you can thus
expect the following amount of false-positive results:
  0.80 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.16 false positives, when considering a   1% risk acceptance (**, ***),
  0.02 false positives, when considering a 0.1% risk acceptance (***)
```