### PR TITLE
stream: use state bitfield for internal checks

### DIFF
--- a/lib/internal/streams/iter/classic.js
+++ b/lib/internal/streams/iter/classic.js
@@ -68,6 +68,10 @@ const {
 
 const { Buffer } = require('buffer');
 const destroyImpl = require('internal/streams/destroy');
+const {
+  kState,
+  kObjectMode,
+} = require('internal/streams/utils');
 
 // Lazy-loaded to avoid circular dependencies. Readable and Writable
 // both require this module's parent, so we defer the require.
@@ -233,7 +237,7 @@ function fromReadable(readable) {
   // Determine normalization. If the stream has _readableState, use it
   // to detect object-mode / encoding. Otherwise assume byte-mode.
   const state = readable._readableState;
-  const normalize = (state && (state.objectMode || state.encoding)) ?
+  const normalize = (state && ((state[kState] & kObjectMode) !== 0 || state.encoding)) ?
     normalizeBatch : null;
 
   const iter = createBatchedAsyncIterator(readable, normalize);

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -41,6 +41,10 @@ const {
   isWebStream,
   isReadableStream,
   isReadableFinished,
+  kState,
+  kErrorEmitted,
+  kErrored,
+  kReadableEnded,
 } = require('internal/streams/utils');
 const { AbortController } = require('internal/abort_controller');
 
@@ -449,7 +453,7 @@ function pipe(src, dst, finish, finishOnlyHandleError, { end }) {
     if (
       err &&
       err.code === 'ERR_STREAM_PREMATURE_CLOSE' &&
-      (rState?.ended && !rState.errored && !rState.errorEmitted)
+      (rState && (rState[kState] & (kReadableEnded | kErrorEmitted | kErrored)) === kReadableEnded)
     ) {
       // Some readable streams will emit 'close' before 'end'. However, since
       // this is on the readable side 'end' should still be emitted if the

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -75,6 +75,10 @@ const {
   kCloseEmitted,
   kErrored,
   kConstructed,
+  kWritableNeedDrain,
+  kWritableFinished,
+  kWritableHasWritable,
+  kWritableWritable,
   kOnConstructed,
 } = require('internal/streams/utils');
 
@@ -985,7 +989,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     // So, if this is awaiting a drain, then we just call it now.
     // If we don't know, then assume that we are waiting for one.
     if (ondrain && state.awaitDrainWriters &&
-        (!dest._writableState || dest._writableState.needDrain))
+        (!dest._writableState || (dest._writableState[kState] & kWritableNeedDrain) !== 0))
       ondrain();
   }
 
@@ -1038,7 +1042,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     dest.removeListener('error', onerror);
     if (dest.listenerCount('error') === 0) {
       const s = dest._writableState || dest._readableState;
-      if (s && !s.errorEmitted) {
+      if (s && (s[kState] & kErrorEmitted) === 0) {
         // User incorrectly emitted 'error' directly on the stream.
         errorOrDestroy(dest, er);
       } else {
@@ -1745,15 +1749,16 @@ function endReadableNT(state, stream) {
 
     if (stream.writable && stream.allowHalfOpen === false) {
       process.nextTick(endWritableNT, stream);
-    } else if (state.autoDestroy) {
+    } else if ((state[kState] & kAutoDestroy) !== 0) {
       // In case of duplex streams we need a way to detect
       // if the writable side is ready for autoDestroy as well.
       const wState = stream._writableState;
       const autoDestroy = !wState || (
-        wState.autoDestroy &&
+        (wState[kState] & kAutoDestroy) !== 0 &&
         // We don't expect the writable to ever 'finish'
         // if writable is explicitly set to false.
-        (wState.finished || wState.writable === false)
+        ((wState[kState] & kWritableFinished) !== 0 ||
+          (wState[kState] & (kWritableHasWritable | kWritableWritable)) === kWritableHasWritable)
       );
 
       if (autoDestroy) {
@@ -1837,7 +1842,7 @@ Readable.wrap = function(src, options) {
       ({ kValidatedSource } = require('internal/streams/iter/types'));
     }
     const state = this._readableState;
-    const normalize = (state.objectMode || state.encoding) ?
+    const normalize = ((state[kState] & kObjectMode) !== 0 || state.encoding) ?
       normalizeBatch : null;
     const iter = createBatchedAsyncIterator(this, normalize);
     iter[kValidatedSource] = true;

--- a/lib/internal/streams/state.js
+++ b/lib/internal/streams/state.js
@@ -7,6 +7,10 @@ const {
 const { validateInteger } = require('internal/validators');
 
 const { ERR_INVALID_ARG_VALUE } = require('internal/errors').codes;
+const {
+  kState,
+  kObjectMode,
+} = require('internal/streams/utils');
 
 // TODO (fix): For some reason Windows CI fails with bigger hwm.
 let defaultHighWaterMarkBytes = process.platform === 'win32' ? 16 * 1024 : 64 * 1024;
@@ -41,7 +45,7 @@ function getHighWaterMark(state, options, duplexKey, isDuplex) {
   }
 
   // Default value
-  return getDefaultHighWaterMark(state.objectMode);
+  return getDefaultHighWaterMark((state[kState] & kObjectMode) !== 0);
 }
 
 module.exports = {

--- a/lib/internal/streams/transform.js
+++ b/lib/internal/streams/transform.js
@@ -74,6 +74,11 @@ const {
 } = require('internal/errors').codes;
 const Duplex = require('internal/streams/duplex');
 const { getHighWaterMark } = require('internal/streams/state');
+const {
+  kState,
+  kReadableEnded,
+  kWritableEnded,
+} = require('internal/streams/utils');
 ObjectSetPrototypeOf(Transform.prototype, Duplex.prototype);
 ObjectSetPrototypeOf(Transform, Duplex);
 
@@ -178,13 +183,13 @@ Transform.prototype._write = function(chunk, encoding, callback) {
       this.push(val);
     }
 
-    if (rState.ended) {
+    if ((rState[kState] & kReadableEnded) !== 0) {
       // If user has called this.push(null) we have to
       // delay the callback to properly propagate the new
       // state.
       process.nextTick(callback);
     } else if (
-      wState.ended || // Backwards compat.
+      (wState[kState] & kWritableEnded) !== 0 || // Backwards compat.
       length === rState.length || // Backwards compat.
       rState.length < rState.highWaterMark
     ) {

--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -32,6 +32,17 @@ const kClosed = 1 << 5;
 const kCloseEmitted = 1 << 6;
 const kErrored = 1 << 7;
 const kConstructed = 1 << 8;
+const kReadableEnded = 1 << 9;
+const kReadableEndEmitted = 1 << 10;
+const kWritableNeedDrain = 1 << 11;
+const kWritableFinished = 1 << 13;
+const kWritableHasWritable = 1 << 21;
+const kWritableWritable = 1 << 22;
+const kWritableEnded = 1 << 30;
+
+function hasBitField(state) {
+  return typeof state?.[kState] === 'number';
+}
 
 function isReadableNodeStream(obj, strict = false) {
   return !!(
@@ -122,7 +133,11 @@ function isDestroyed(stream) {
   const wState = stream._writableState;
   const rState = stream._readableState;
   const state = wState || rState;
-  return !!(stream.destroyed || stream[kIsDestroyed] || state?.destroyed);
+  return !!(
+    stream.destroyed ||
+    stream[kIsDestroyed] ||
+    (hasBitField(state) ? (state[kState] & kDestroyed) !== 0 : state?.destroyed)
+  );
 }
 
 // Have been end():d.
@@ -130,9 +145,14 @@ function isWritableEnded(stream) {
   if (!isWritableNodeStream(stream)) return null;
   if (stream.writableEnded === true) return true;
   const wState = stream._writableState;
-  if (wState?.errored) return false;
-  if (typeof wState?.ended !== 'boolean') return null;
-  return wState.ended;
+  if (!wState) return null;
+  if (!hasBitField(wState)) {
+    if (wState.errored) return false;
+    if (typeof wState.ended !== 'boolean') return null;
+    return wState.ended;
+  }
+  if ((wState[kState] & kErrored) !== 0) return false;
+  return (wState[kState] & kWritableEnded) !== 0;
 }
 
 // Have emitted 'finish'.
@@ -140,11 +160,19 @@ function isWritableFinished(stream, strict) {
   if (!isWritableNodeStream(stream)) return null;
   if (stream.writableFinished === true) return true;
   const wState = stream._writableState;
-  if (wState?.errored) return false;
-  if (typeof wState?.finished !== 'boolean') return null;
+  if (!wState) return null;
+  if (!hasBitField(wState)) {
+    if (wState.errored) return false;
+    if (typeof wState.finished !== 'boolean') return null;
+    return !!(
+      wState.finished ||
+      (strict === false && wState.ended === true && wState.length === 0)
+    );
+  }
+  if ((wState[kState] & kErrored) !== 0) return false;
   return !!(
-    wState.finished ||
-    (strict === false && wState.ended === true && wState.length === 0)
+    (wState[kState] & kWritableFinished) !== 0 ||
+    (strict === false && (wState[kState] & kWritableEnded) !== 0 && wState.length === 0)
   );
 }
 
@@ -153,20 +181,33 @@ function isReadableEnded(stream) {
   if (!isReadableNodeStream(stream)) return null;
   if (stream.readableEnded === true) return true;
   const rState = stream._readableState;
-  if (!rState || rState.errored) return false;
-  if (typeof rState?.ended !== 'boolean') return null;
-  return rState.ended;
+  if (!rState) return false;
+  if (!hasBitField(rState)) {
+    if (rState.errored) return false;
+    if (typeof rState.ended !== 'boolean') return null;
+    return rState.ended;
+  }
+  if ((rState[kState] & kErrored) !== 0) return false;
+  return (rState[kState] & kReadableEnded) !== 0;
 }
 
 // Have emitted 'end'.
 function isReadableFinished(stream, strict) {
   if (!isReadableNodeStream(stream)) return null;
   const rState = stream._readableState;
-  if (rState?.errored) return false;
-  if (typeof rState?.endEmitted !== 'boolean') return null;
+  if (!rState) return null;
+  if (!hasBitField(rState)) {
+    if (rState.errored) return false;
+    if (typeof rState.endEmitted !== 'boolean') return null;
+    return !!(
+      rState.endEmitted ||
+      (strict === false && rState.ended === true && rState.length === 0)
+    );
+  }
+  if ((rState[kState] & kErrored) !== 0) return false;
   return !!(
-    rState.endEmitted ||
-    (strict === false && rState.ended === true && rState.length === 0)
+    (rState[kState] & kReadableEndEmitted) !== 0 ||
+    (strict === false && (rState[kState] & kReadableEnded) !== 0 && rState.length === 0)
   );
 }
 
@@ -289,8 +330,17 @@ function willEmitClose(stream) {
   const rState = stream._readableState;
   const state = wState || rState;
 
-  return (!state && isServerResponse(stream)) || !!(
-    state?.autoDestroy &&
+  if (!state) {
+    return isServerResponse(stream);
+  }
+
+  if (hasBitField(state)) {
+    return (state[kState] & (kAutoDestroy | kEmitClose | kClosed)) ===
+      (kAutoDestroy | kEmitClose);
+  }
+
+  return !!(
+    state.autoDestroy &&
     state.emitClose &&
     state.closed === false
   );
@@ -304,14 +354,21 @@ function isDisturbed(stream) {
 }
 
 function isErrored(stream) {
+  const rState = stream?._readableState;
+  const wState = stream?._writableState;
+  const rStateErrored = hasBitField(rState) ?
+    (rState[kState] & (kErrorEmitted | kErrored)) !== 0 :
+    rState?.errorEmitted ?? rState?.errored;
+  const wStateErrored = hasBitField(wState) ?
+    (wState[kState] & (kErrorEmitted | kErrored)) !== 0 :
+    wState?.errorEmitted ?? wState?.errored;
+
   return !!(stream && (
     stream[kIsErrored] ??
     stream.readableErrored ??
     stream.writableErrored ??
-    stream._readableState?.errorEmitted ??
-    stream._writableState?.errorEmitted ??
-    stream._readableState?.errored ??
-    stream._writableState?.errored
+    rStateErrored ??
+    wStateErrored
   ));
 }
 
@@ -360,4 +417,11 @@ module.exports = {
   kCloseEmitted,
   kErrored,
   kConstructed,
+  kReadableEnded,
+  kReadableEndEmitted,
+  kWritableNeedDrain,
+  kWritableFinished,
+  kWritableHasWritable,
+  kWritableWritable,
+  kWritableEnded,
 };

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -81,6 +81,7 @@ const {
   kCloseEmitted,
   kErrored,
   kConstructed,
+  kReadableEndEmitted,
   kOnConstructed,
 } = require('internal/streams/utils');
 
@@ -726,16 +727,17 @@ function errorBuffer(state) {
   }
 
   if ((state[kState] & kBuffered) !== 0) {
-    for (let n = state.bufferedIndex; n < state.buffered.length; ++n) {
+    for (let n = state.bufferedIndex; n < state[kBufferedValue].length; ++n) {
       const { chunk, callback } = state[kBufferedValue][n];
       const len = (state[kState] & kObjectMode) !== 0 ? 1 : chunk.length;
       state.length -= len;
-      callback(state.errored ?? new ERR_STREAM_DESTROYED('write'));
+      callback((state[kState] & kErrored) !== 0 ? state[kErroredValue] : new ERR_STREAM_DESTROYED('write'));
     }
   }
 
-
-  callFinishedCallbacks(state, state.errored ?? new ERR_STREAM_DESTROYED('end'));
+  const err = (state[kState] & kErrored) !== 0 ?
+    state[kErroredValue] : new ERR_STREAM_DESTROYED('end');
+  callFinishedCallbacks(state, err);
 
   resetBuffer(state);
 }
@@ -959,10 +961,10 @@ function finish(stream, state) {
     // if the readable side is ready for autoDestroy as well.
     const rState = stream._readableState;
     const autoDestroy = !rState || (
-      rState.autoDestroy &&
+      (rState[kState] & kAutoDestroy) !== 0 &&
       // We don't expect the readable to ever 'end'
       // if readable is explicitly set to false.
-      (rState.endEmitted || rState.readable === false)
+      ((rState[kState] & kReadableEndEmitted) !== 0 || rState.readable === false)
     );
     if (autoDestroy) {
       stream.destroy();
@@ -1013,7 +1015,8 @@ ObjectDefineProperties(Writable.prototype, {
       // where the writable side was disabled upon construction.
       // Compat. The user might manually disable writable side through
       // deprecated setter.
-      return !!w && w.writable !== false &&
+      return !!w &&
+        (w[kState] & (kHasWritable | kWritable)) !== kHasWritable &&
         (w[kState] & (kEnding | kEnded | kDestroyed | kErrored)) === 0;
     },
     set(val) {
@@ -1093,7 +1096,7 @@ ObjectDefineProperties(Writable.prototype, {
     enumerable: false,
     get() {
       const state = this._writableState;
-      return state ? state.errored : null;
+      return state && (state[kState] & kErrored) !== 0 ? state[kErroredValue] : null;
     },
   },
 


### PR DESCRIPTION
```console
                                                                                         confidence improvement accuracy (*)   (**)  (***)
streams/finished.js streamType='readable' n=10000000                                                     1.10 %       ±2.31% ±3.16% ±4.31%
streams/finished.js streamType='writable' n=10000000                                                     1.03 %       ±1.73% ±2.38% ±3.24%
streams/pipe.js n=5000000                                                                               -1.45 %       ±3.30% ±4.71% ±6.86%
streams/readable-async-iterator.js sync='no' n=100000                                                    0.10 %       ±1.49% ±2.04% ±2.78%
streams/readable-async-iterator.js sync='yes' n=100000                                                  -0.29 %       ±2.29% ±3.14% ±4.28%
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='no' n=100000                     0.32 %       ±1.68% ±2.34% ±3.30%
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='yes' n=100000                    0.27 %       ±3.03% ±4.15% ±5.66%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='no' n=100000                   -1.12 %       ±3.18% ±4.44% ±6.24%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='yes' n=100000                   0.92 %       ±4.18% ±5.80% ±8.05%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='no' n=100000                    0.15 %       ±1.33% ±1.84% ±2.53%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='yes' n=100000                   1.70 %       ±2.29% ±3.13% ±4.27%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='no' n=100000            *      3.41 %       ±3.15% ±4.39% ±6.11%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='yes' n=100000                 -0.54 %       ±3.43% ±4.76% ±6.63%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='no' n=100000                    0.99 %       ±1.35% ±1.85% ±2.53%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='yes' n=100000                   0.23 %       ±2.26% ±3.11% ±4.29%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='no' n=100000                   1.26 %       ±1.28% ±1.75% ±2.39%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='yes' n=100000                  0.51 %       ±2.99% ±4.11% ±5.62%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='no' n=100000                  -0.35 %       ±2.10% ±2.92% ±4.07%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='yes' n=100000                  2.01 %       ±4.08% ±5.76% ±8.22%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='no' n=100000                 -0.63 %       ±2.35% ±3.22% ±4.39%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='yes' n=100000                 0.64 %       ±3.14% ±4.31% ±5.87%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 21 comparisons, you can thus
expect the following amount of false-positive results:
  1.05 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.21 false positives, when considering a   1% risk acceptance (**, ***),
  0.02 false positives, when considering a 0.1% risk acceptance (***)
```