### PR TITLE
stream: allow reusable stateless transform options

### DIFF
--- a/lib/internal/streams/iter/pull.js
+++ b/lib/internal/streams/iter/pull.js
@@ -12,6 +12,7 @@ const {
   ArrayIsArray,
   ArrayPrototypePush,
   ArrayPrototypeSlice,
+  ObjectFreeze,
   PromisePrototypeThen,
   SymbolAsyncIterator,
   SymbolIterator,
@@ -56,6 +57,7 @@ const {
 
 const {
   drainableProtocol,
+  kReusableTransformOptions,
   kSyncWriteAcceptedOnFalse,
   kValidatedSource,
   kValidatedTransform,
@@ -497,6 +499,13 @@ function* createSyncPipeline(source, transforms) {
  * Apply a single stateless async transform to a source.
  * @yields {Uint8Array[]}
  */
+function hasReusableOptionsTransform(run) {
+  for (let i = 0; i < run.length; i++) {
+    if (run[i][kReusableTransformOptions]) return true;
+  }
+  return false;
+}
+
 /**
  * Apply a fused run of stateless async transforms to a source.
  * All transforms in the run are applied in a tight synchronous loop per batch,
@@ -504,17 +513,83 @@ function* createSyncPipeline(source, transforms) {
  *
  * INVARIANT: This function accepts a signal, NOT a pre-built options object.
  * A fresh { __proto__: null, signal } options object is created for each
- * transform invocation to prevent cross-transform mutation.
+ * public transform invocation to prevent cross-transform mutation. Internal
+ * transforms can opt into a frozen shared object with
+ * kReusableTransformOptions when they do not mutate options or depend on
+ * options identity.
  * @param {AsyncIterable<Uint8Array[]>} source
  * @param {Array<Function>} run - Array of stateless transform functions
  * @param {AbortSignal} signal - The pipeline's abort signal
  * @yields {Uint8Array[]}
  */
 async function* applyFusedStatelessAsyncTransforms(source, run, signal) {
+  const reusableOptions = hasReusableOptionsTransform(run) ?
+    ObjectFreeze({ __proto__: null, signal }) : undefined;
+  if (reusableOptions === undefined) {
+    for await (const chunks of source) {
+      let current = chunks;
+      for (let i = 0; i < run.length; i++) {
+        const result = run[i](current, { __proto__: null, signal });
+        if (result === null) {
+          current = null;
+          break;
+        }
+        if (isPromise(result)) {
+          const resolved = await result;
+          if (resolved === null) {
+            current = null;
+            break;
+          }
+          current = resolved;
+        } else {
+          current = result;
+        }
+      }
+      if (current === null) continue;
+      // Normalize the final output
+      if (isUint8ArrayBatch(current)) {
+        if (current.length > 0) yield current;
+      } else if (isUint8Array(current)) {
+        yield [current];
+      } else if (typeof current === 'string') {
+        yield [toUint8Array(current)];
+      } else if (isAnyArrayBuffer(current)) {
+        yield [new Uint8Array(current)];
+      } else if (ArrayBufferIsView(current)) {
+        yield [arrayBufferViewToUint8Array(current)];
+      } else {
+        yield* processTransformResultAsync(current);
+      }
+    }
+    // Flush each transform after all upstream data, including data emitted by
+    // earlier flushes, has been processed by that transform.
+    let pending = [];
+    for (let i = 0; i < run.length; i++) {
+      const next = [];
+      for (let j = 0; j < pending.length; j++) {
+        await appendTransformResultAsync(
+          next,
+          run[i](pending[j], { __proto__: null, signal }));
+      }
+      await appendTransformResultAsync(
+        next,
+        run[i](null, { __proto__: null, signal }));
+      pending = next;
+    }
+    for (let i = 0; i < pending.length; i++) {
+      yield pending[i];
+    }
+    return;
+  }
+
   for await (const chunks of source) {
     let current = chunks;
     for (let i = 0; i < run.length; i++) {
-      const result = run[i](current, { __proto__: null, signal });
+      const transform = run[i];
+      const result = transform(
+        current,
+        transform[kReusableTransformOptions] ?
+          reusableOptions : { __proto__: null, signal });
       if (result === null) {
         current = null;
         break;
@@ -551,14 +626,21 @@ async function* applyFusedStatelessAsyncTransforms(source, run, signal) {
   let pending = [];
   for (let i = 0; i < run.length; i++) {
     const next = [];
+    const transform = run[i];
     for (let j = 0; j < pending.length; j++) {
       await appendTransformResultAsync(
         next,
-        run[i](pending[j], { __proto__: null, signal }));
+        transform(
+          pending[j],
+          transform[kReusableTransformOptions] ?
+            reusableOptions : { __proto__: null, signal }));
     }
     await appendTransformResultAsync(
       next,
-      run[i](null, { __proto__: null, signal }));
+      transform(
+        null,
+        transform[kReusableTransformOptions] ?
+          reusableOptions : { __proto__: null, signal }));
     pending = next;
   }
   for (let i = 0; i < pending.length; i++) {

--- a/lib/internal/streams/iter/types.js
+++ b/lib/internal/streams/iter/types.js
@@ -56,6 +56,15 @@ const drainableProtocol = SymbolFor('Stream.drainableProtocol');
 const kValidatedTransform = Symbol('kValidatedTransform');
 
 /**
+ * Internal sentinel for stateless transforms that can receive a frozen,
+ * shared options object. A transform function with
+ * [kReusableTransformOptions] = true signals that it does not mutate the
+ * options object and does not depend on per-invocation options identity.
+ * This is NOT a public protocol symbol - it uses Symbol() not Symbol.for().
+ */
+const kReusableTransformOptions = Symbol('kReusableTransformOptions');
+
+/**
  * Internal sentinel for validated sources. An async iterable with
  * [kValidatedSource] = true signals that it already yields valid
  * Uint8Array[] batches - no normalizeAsyncSource wrapper needed.
@@ -81,6 +90,7 @@ const kSyncWriteAcceptedOnFalse = Symbol('kSyncWriteAcceptedOnFalse');
 module.exports = {
   broadcastProtocol,
   drainableProtocol,
+  kReusableTransformOptions,
   kSyncWriteAccepted,
   kSyncWriteAcceptedOnFalse,
   kValidatedSource,

--- a/test/parallel/test-stream-iter-pull-async.js
+++ b/test/parallel/test-stream-iter-pull-async.js
@@ -1,9 +1,12 @@
-// Flags: --experimental-stream-iter
+// Flags: --experimental-stream-iter --expose-internals
 'use strict';
 
 const common = require('../common');
 const assert = require('assert');
 const { pull, from, text, tap } = require('stream/iter');
+const {
+  kReusableTransformOptions,
+} = require('internal/streams/iter/types');
 
 async function testPullIdentity() {
   const data = await text(pull(from('hello-async')));
@@ -349,6 +352,36 @@ async function testTransformOptionsNotShared() {
   assert.strictEqual(seen[1].mutated, undefined);
 }
 
+async function testReusableTransformOptions() {
+  const reusableOptions = [];
+  const regularOptions = [];
+  const reusable = (chunks, options) => {
+    reusableOptions.push(options);
+    assert(Object.isFrozen(options));
+    return chunks;
+  };
+  reusable[kReusableTransformOptions] = true;
+
+  const regular = (chunks, options) => {
+    regularOptions.push(options);
+    assert(!Object.isFrozen(options));
+    return chunks;
+  };
+
+  await text(pull(from(['a', 'b']), reusable, regular, reusable));
+
+  assert(reusableOptions.length > 1);
+  for (let i = 1; i < reusableOptions.length; i++) {
+    assert.strictEqual(reusableOptions[i], reusableOptions[0]);
+  }
+  for (let i = 0; i < regularOptions.length; i++) {
+    assert.notStrictEqual(regularOptions[i], reusableOptions[0]);
+    for (let j = i + 1; j < regularOptions.length; j++) {
+      assert.notStrictEqual(regularOptions[i], regularOptions[j]);
+    }
+  }
+}
+
 // Run the uncaughtException test sequentially (it installs a global handler
 // that would interfere with concurrent tests).
 (async () => {
@@ -376,6 +409,7 @@ async function testTransformOptionsNotShared() {
     testTransformReturnsArrayBuffer(),
     testPipeToStringSource(),
     testTransformOptionsNotShared(),
+    testReusableTransformOptions(),
   ]);
   // Run after all concurrent tests complete to avoid global handler races
   await testTransformSignalListenerErrorOnSourceError();


### PR DESCRIPTION
Add an internal opt-in marker for async stateless transforms that can receive a frozen shared options object. Keep public transforms on the existing fresh options path so mutation semantics are preserved.


Assisted-by: openai:gpt-5.5