### PR TITLE
stream: bound pipeTo sync source normalization

### DIFF
--- a/lib/internal/streams/iter/from.js
+++ b/lib/internal/streams/iter/from.js
@@ -623,6 +623,7 @@ function from(input) {
 // =============================================================================
 
 module.exports = {
+  FROM_BATCH_SIZE,
   arrayBufferViewToUint8Array,
   from,
   fromSync,

--- a/lib/internal/streams/iter/pull.js
+++ b/lib/internal/streams/iter/pull.js
@@ -8,7 +8,6 @@
 
 const {
   ArrayBufferIsView,
-  ArrayFromAsync,
   ArrayIsArray,
   ArrayPrototypePush,
   ArrayPrototypeSlice,
@@ -35,6 +34,7 @@ const {
 const { AbortController } = require('internal/abort_controller');
 
 const {
+  FROM_BATCH_SIZE,
   arrayBufferViewToUint8Array,
   from,
   fromSync,
@@ -948,6 +948,23 @@ async function pipeTo(source, ...args) {
     }
   }
 
+  // Normalize a single yielded value and write chunks in bounded batches.
+  async function writeNormalizedValue(value) {
+    let batch = [];
+    for await (const chunk of normalizeAsyncValue(value)) {
+      ArrayPrototypePush(batch, chunk);
+      if (batch.length === FROM_BATCH_SIZE) {
+        const p = writeBatch(batch);
+        if (p) await p;
+        batch = [];
+      }
+    }
+    if (batch.length > 0) {
+      const p = writeBatch(batch);
+      if (p) await p;
+    }
+  }
+
   try {
     if (useSyncIterableFastPath) {
       // Avoid from()'s async sync-iterable batching path. This keeps writes
@@ -967,11 +984,7 @@ async function pipeTo(source, ...args) {
           continue;
         }
 
-        const batch = await ArrayFromAsync(normalizeAsyncValue(value));
-        if (batch.length > 0) {
-          const p = writeBatch(batch);
-          if (p) await p;
-        }
+        await writeNormalizedValue(value);
       }
     } else if (transforms.length === 0) {
       // Fast path: no transforms - iterate normalized source directly

--- a/test/parallel/test-stream-iter-pipeto.js
+++ b/test/parallel/test-stream-iter-pipeto.js
@@ -292,6 +292,44 @@ async function testPipeToSyncIterableFastPathAsyncValue() {
   assert.strictEqual(result, 'ab');
 }
 
+async function testPipeToSyncIterableFastPathNestedValueBounded() {
+  let pulled = 0;
+  let firstWritePulled = 0;
+  const batches = [];
+  const writes = [];
+  const writer = {
+    write: common.mustNotCall(),
+    writeSync(chunk) {
+      writes.push(chunk);
+      return true;
+    },
+    writev: common.mustNotCall(),
+    writevSync(chunks) {
+      if (firstWritePulled === 0) {
+        firstWritePulled = pulled;
+      }
+      batches.push(chunks);
+      return true;
+    },
+  };
+  function* nested() {
+    for (let i = 0; i < 129; i++) {
+      pulled++;
+      yield new Uint8Array([i]);
+    }
+  }
+  function* source() {
+    yield nested();
+  }
+
+  const totalBytes = await pipeTo(source(), writer);
+  assert.strictEqual(totalBytes, 129);
+  assert.strictEqual(firstWritePulled, 128);
+  assert.strictEqual(batches.length, 1);
+  assert.strictEqual(batches[0].length, 128);
+  assert.deepStrictEqual(writes, [new Uint8Array([128])]);
+}
+
 Promise.all([
   testPipeToSync(),
   testPipeTo(),
@@ -310,4 +348,5 @@ Promise.all([
   testPipeToSyncIterableFastPathWritesIncrementally(),
   testPipeToSyncIterableFastPathWriteFallback(),
   testPipeToSyncIterableFastPathAsyncValue(),
+  testPipeToSyncIterableFastPathNestedValueBounded(),
 ]).then(common.mustCall());


### PR DESCRIPTION
Avoid materializing all chunks produced while normalizing a single non-fast-path value in the sync iterable pipeTo fast path. Write normalized chunks incrementally in FROM_BATCH_SIZE batches instead, reducing peak memory and latency for nested iterable values.