### PR TITLE
debugger: wait for init after restart

### DIFF
--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -372,6 +372,7 @@ function createRepl(inspector) {
   const knownBreakpoints = [];
   let heapSnapshotPromise = null;
   let pauseOnExceptionState = 'none';
+  let initPromise = PromiseResolve();
   let lastCommand;
 
   // Things we need to reset when the app restarts
@@ -962,7 +963,7 @@ function createRepl(inspector) {
       },
 
       get run() {
-        return inspector.run();
+        return PromisePrototypeThen(inspector.run(), () => initPromise);
       },
 
       get kill() {
@@ -970,7 +971,7 @@ function createRepl(inspector) {
       },
 
       get restart() {
-        return inspector.run();
+        return PromisePrototypeThen(inspector.run(), () => initPromise);
       },
 
       get cont() {
@@ -1192,16 +1193,21 @@ function createRepl(inspector) {
     return Runtime.runIfWaitingForDebugger();
   }
 
+  function initOnReady() {
+    initPromise = initAfterStart();
+    return initPromise;
+  }
+
   return async function startRepl() {
     inspector.client.on('close', () => {
       resetOnStart();
     });
     inspector.client.on('ready', () => {
-      initAfterStart();
+      initOnReady();
     });
 
     // Init once for the initial connection
-    await initAfterStart();
+    await initOnReady();
 
     const replOptions = {
       prompt: 'debug> ',


### PR DESCRIPTION
Fixes a debugger CLI restart race where `run`/`restart` could complete as soon
as the inspector websocket connected, before the post-connect debugger
initialization had finished.

The command now waits for the initialization promise that enables the debugger,
restores debugger state, and sends `Runtime.runIfWaitingForDebugger()`. This
makes restart synchronization wait for the debuggee to be ready to produce the
initial break event instead of only waiting for the connection.

Refs:
* https://github.com/nodejs/node/actions/runs/26533911441/job/78157541700
* https://github.com/nodejs/node/actions/runs/26518409888/job/78102124966
* https://github.com/nodejs/node/actions/runs/26503176764/job/78048663317

<details>
<summary>Error log</summary>

```console
Path: parallel/test-debugger-exceptions
Error: --- stderr ---
/Users/runner/work/node/node/node/test/common/debugger.js:92
        const timeoutErr = new Error(`Timeout (${TIMEOUT}) while waiting for ${pattern}`);
                           ^

Error: Timeout (15000) while waiting for /break (?:on start )?in/i
    at /Users/runner/work/node/node/node/test/common/debugger.js:92:28
    at new Promise (<anonymous>)
    at Object.waitFor (/Users/runner/work/node/node/node/test/common/debugger.js:67:14)
    at Object.waitForInitialBreak (/Users/runner/work/node/node/node/test/common/debugger.js:116:18)
    at /Users/runner/work/node/node/node/test/parallel/test-debugger-exceptions.js:55:17
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5) {
  output: '< Debugger ending on ws://127.0.0.1:55106/bd3b1054-e004-4647-befb-bbcded26c129\n' +
    '< For help, see: [https://nodejs.org/learn/getting-started/debugging\n](https://nodejs.org/learn/getting-started/debugging/n)' +
    '< \n' +
    'debug> \n' +
    '< Debugger listening on ws://127.0.0.1:55109/38edde6c-fc97-464e-8e96-27cdb85f5cef\n' +
    '< For help, see: [https://nodejs.org/learn/getting-started/debugging\n](https://nodejs.org/learn/getting-started/debugging/n)' +
    '< \n' +
    'debug> connecting to 127.0.0.1:55109 ...\n' +
    '< Debugger attached.\n' +
    '< \n' +
    'debug>  ok\n' +
    'debug> '
}
```

</details>

---

Assisted-by: openai:gpt-5.5