### PR TITLE
debugger: wait for initial pause during startup

### DIFF
--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -380,6 +380,7 @@ function createRepl(inspector) {
   let selectedFrame;
   let exitDebugRepl;
   let contextLineNumber = 2;
+  let pauseHandled = PromiseResolve();
 
   function resetOnStart() {
     knownScripts = {};
@@ -895,7 +896,7 @@ function createRepl(inspector) {
         reason === 'Break on start') {
       debuglog('Paused on start, but NODE_INSPECT_RESUME_ON_START' +
               ' environment variable is set to 1, resuming');
-      inspector.client.callMethod('Debugger.resume');
+      pauseHandled = inspector.client.callMethod('Debugger.resume');
       return;
     }
 
@@ -910,7 +911,7 @@ function createRepl(inspector) {
 
     const header = `${breakType} in ${scriptUrl}:${lineNumber + 1}`;
 
-    inspector.suspendReplWhile(() =>
+    pauseHandled = inspector.suspendReplWhile(() =>
       PromisePrototypeThen(
         SafePromiseAllReturnArrayLike([formatWatchers(true), selectedFrame.list(contextLineNumber)]),
         ({ 0: watcherList, 1: context }) => {
@@ -1186,6 +1187,9 @@ function createRepl(inspector) {
   }
 
   async function initAfterStart() {
+    const initialPause = inspector.options?.script ?
+      new Promise((resolve) => Debugger.once('paused', resolve)) :
+      PromiseResolve();
     await Runtime.enable();
     await Profiler.enable();
     await Profiler.setSamplingInterval({ interval: 100 });
@@ -1194,7 +1198,9 @@ function createRepl(inspector) {
     await Debugger.setBlackboxPatterns({ patterns: [] });
     await Debugger.setPauseOnExceptions({ state: pauseOnExceptionState });
     await restoreBreakpoints();
-    return Runtime.runIfWaitingForDebugger();
+    await Runtime.runIfWaitingForDebugger();
+    await initialPause;
+    return pauseHandled;
   }
 
   return async function startRepl() {

--- a/test/parallel/test-debugger-run-restart-init.js
+++ b/test/parallel/test-debugger-run-restart-init.js
@@ -36,6 +36,7 @@ function createAgent(domain, calls, gates) {
   agent.setBlackboxPatterns = method('setBlackboxPatterns');
   agent.setPauseOnExceptions = method('setPauseOnExceptions');
   agent.runIfWaitingForDebugger = method('runIfWaitingForDebugger');
+  agent.getScriptSource = async () => ({ scriptSource: "'use strict';\n" });
   return agent;
 }
 
@@ -114,6 +115,71 @@ async function assertCommandWaitsForInit(repl, command, gate, calls) {
       'Runtime.runIfWaitingForDebugger',
     ],
   );
+
+  repl.close();
+})().then(common.mustCall());
+
+(async () => {
+  const calls = [];
+  const pauseGate = createGate();
+  const inspector = {
+    options: { script: 'three-lines.js' },
+    client: new EventEmitter(),
+    domainNames: ['Debugger', 'HeapProfiler', 'Profiler', 'Runtime'],
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    run: common.mustNotCall(),
+    print(value, addNewline = true) {
+      this.stdout.write(addNewline ? `${value}\n` : value);
+    },
+    async suspendReplWhile(fn) {
+      calls.push('suspendReplWhile');
+      await fn();
+      await pauseGate.promise;
+    },
+  };
+
+  for (const domain of inspector.domainNames) {
+    inspector[domain] = createAgent(domain, calls, [null]);
+  }
+
+  let settled = false;
+  const replPromise = createRepl(inspector)().then((repl) => {
+    settled = true;
+    return repl;
+  });
+
+  await new Promise(setImmediate);
+  assert.strictEqual(
+    settled,
+    false,
+    'startRepl resolved before receiving the initial pause',
+  );
+
+  inspector.Debugger.emit('scriptParsed', {
+    scriptId: '1',
+    url: '/tmp/three-lines.js',
+  });
+  inspector.Debugger.emit('paused', {
+    reason: 'Break on start',
+    callFrames: [{
+      functionName: '',
+      location: { scriptId: '1', lineNumber: 0, columnNumber: 0 },
+      scopeChain: [],
+    }],
+  });
+
+  await new Promise(setImmediate);
+  assert.strictEqual(
+    settled,
+    false,
+    'startRepl resolved before the initial pause was handled',
+  );
+
+  pauseGate.resolve();
+  const repl = await replPromise;
+  assert.strictEqual(settled, true);
+  assert.match(inspector.stdout.read().toString(), /Break on start in/);
 
   repl.close();
 })().then(common.mustCall());


### PR DESCRIPTION
Fix a debugger CLI startup synchronization race.

`startRepl()` awaited debugger domain initialization and
`Runtime.runIfWaitingForDebugger()`, but it did not wait for the resulting
initial `Debugger.paused` event to be handled before starting the REPL.

That allowed the `debug>` prompt to appear before the initial break message was
printed. In slow CI runs, `parallel/test-debugger-run-after-quit-restart` could
time out while waiting for the first break, even though the debugger had already
attached.

This changes local script startup to wait for the initial pause event and for
its pause formatting to complete before resolving initialization. Remote attach
behavior is left unchanged.

Refs: https://github.com/nodejs/node/actions/runs/27582782593/job/81546582775