### PR TITLE
debugger: retry initial probe release

### DIFF
--- a/lib/internal/debugger/inspect_probe.js
+++ b/lib/internal/debugger/inspect_probe.js
@@ -43,6 +43,7 @@ const {
 } = internalBinding('errors');
 
 const kProbeDefaultTimeout = 30000;
+const kProbeInitialReleaseRetryInterval = 50;
 const kProbeVersion = 2;
 const kProbeDisconnectSentinel = 'Waiting for the debugger to disconnect...';
 const kProbeAttachedSentinel = 'Debugger attached.';
@@ -461,6 +462,9 @@ class ProbeInspectorSession {
     // via `Runtime.runIfWaitingForDebugger`.
     // Distinguishes "exited before user code ran" from "exited during the live session".
     this.started = false;
+    // True once the target reports activity that can only happen after startup
+    // has moved past the initial inspector wait.
+    this.targetStarted = false;
     // A sliding buffer of at most kProbeDisconnectSentinel.length to detect disconnect.
     this.disconnectSentinelBuffer = '';
     /** @type {Map<string, BreakpointDefinition>} keyed by V8 breakpointId. */
@@ -486,6 +490,29 @@ class ProbeInspectorSession {
     this.onClientClose = FunctionPrototypeBind(this.onClientClose, this);
     this.onPaused = FunctionPrototypeBind(this.onPaused, this);
     this.onScriptParsed = FunctionPrototypeBind(this.onScriptParsed, this);
+  }
+
+  markTargetStarted(reason) {
+    if (this.targetStarted) { return; }
+    debug('target started: %s', reason);
+    this.targetStarted = true;
+  }
+
+  retryInitialRelease() {
+    const timer = setTimeout(() => {
+      if (this.finished || this.targetStarted || this.disconnectRequested) { return; }
+
+      debug('retry Runtime.runIfWaitingForDebugger');
+      this.client.callMethod('Runtime.runIfWaitingForDebugger').then(() => {
+        debug('retry Runtime.runIfWaitingForDebugger (success)');
+      }, (error) => {
+        // This retry is best-effort. Connection loss and target exit are reported
+        // through the normal close/exit handlers, and protocol errors should not
+        // obscure a later, more specific probe failure.
+        debug('retry Runtime.runIfWaitingForDebugger error: %s', error?.code);
+      });
+    }, kProbeInitialReleaseRetryInterval);
+    timer.unref();
   }
 
   // Marking the probing process to exit with 0, recorded hits are trustworthy.
@@ -612,6 +639,7 @@ class ProbeInspectorSession {
 
   onPaused(params) {
     debug('paused: finished=%d, reason=%s hitBreakpoints=%j', this.finished, params.reason, params.hitBreakpoints);
+    this.markTargetStarted('paused');
     this.handlePaused(params).catch((error) => {
       if (error === kInspectorFailedSentinel) { return; }
       this.recordInspectorFailure({
@@ -873,6 +901,7 @@ class ProbeInspectorSession {
   onScriptParsed(params) {
     if (params.url && !StringPrototypeStartsWith(params.url, 'node:')) {
       debug('scriptParsed: scriptId=%s url=%s, length=%d', params.scriptId, params.url, params.length);
+      this.markTargetStarted('scriptParsed');
     }
     // This map grows by the number of scripts parsed, which is limited, and is just a
     // small string -> string map. The lifetime is bounded by probe timeout etc. so cleanup is overkill.
@@ -994,6 +1023,7 @@ class ProbeInspectorSession {
         this.started = true;
         this.startTimeout();
         await this.callCdp('Runtime.runIfWaitingForDebugger');
+        this.retryInitialRelease();
       } catch (err) {
         if (err !== kInspectorFailedSentinel) { throw err; }
       }


### PR DESCRIPTION
This deflakes probe mode startup by retrying `Runtime.runIfWaitingForDebugger`
once shortly after the initial release.

A macOS CI run timed out in `test-debugger-probe-text-special-values`
after the initial release command succeeded, but before any target activity
was observed: no `scriptParsed`, no initial pause, no probe hit, and no target exit.
That suggests the release can occasionally arrive before the target has reached
the initial inspector wait, leaving the child suspended until the probe timeout.

The retry is best-effort and is skipped once the target has started, detected
by either a `Debugger.paused` event or a non-`node:` `Debugger.scriptParsed`
event.

Refs: https://github.com/nodejs/node/actions/runs/27478731451/job/81222628529