### PR TITLE
debugger: add probe logs for inspect-port zero flake

### DIFF
--- a/lib/internal/debugger/inspect_probe.js
+++ b/lib/internal/debugger/inspect_probe.js
@@ -526,8 +526,8 @@ class ProbeInspectorSession {
   }
 
   onChildOutput(text, which) {
+    debug('child %s: %j', which, text);
     if (which !== 'stderr') { return; }
-    debug('child stderr: %j', text);
 
     this.childStderr += text;
 
@@ -611,7 +611,11 @@ class ProbeInspectorSession {
   }
 
   onPaused(params) {
-    debug('paused: finished=%d, reason=%s hitBreakpoints=%j', this.finished, params.reason, params.hitBreakpoints);
+    debug('paused: finished=%d, reason=%s hitBreakpoints=%j topFrameLocation=%j',
+          this.finished,
+          params.reason,
+          params.hitBreakpoints,
+          params.callFrames?.[0]?.location);
     this.handlePaused(params).catch((error) => {
       if (error === kInspectorFailedSentinel) { return; }
       this.recordInspectorFailure({
@@ -871,9 +875,11 @@ class ProbeInspectorSession {
   }
 
   onScriptParsed(params) {
-    if (params.url && !StringPrototypeStartsWith(params.url, 'node:')) {
-      debug('scriptParsed: scriptId=%s url=%s, length=%d', params.scriptId, params.url, params.length);
-    }
+    debug('scriptParsed: scriptId=%s url=%s, length=%d, executionContextId=%s',
+          params.scriptId,
+          params.url,
+          params.length,
+          params.executionContextId);
     // This map grows by the number of scripts parsed, which is limited, and is just a
     // small string -> string map. The lifetime is bounded by probe timeout etc. so cleanup is overkill.
     this.scriptIdToUrl.set(params.scriptId, params.url);

--- a/test/parallel/test-debugger-probe-child-inspect-port-zero.js
+++ b/test/parallel/test-debugger-probe-child-inspect-port-zero.js
@@ -14,6 +14,7 @@ const probeUrl = fixtures.fileURL('debugger', 'probe.js').href;
 spawnSyncAndAssert(process.execPath, [
   'inspect',
   '--json',
+  '--timeout', '5000',
   '--probe', 'probe.js:12',
   '--expr', 'finalValue',
   '--',


### PR DESCRIPTION
This adds temporary probe-mode debug logging to help diagnose a flaky
`test-debugger-probe-child-inspect-port-zero.js` failure seen in macOS CI.

The added `NODE_DEBUG=inspect_probe` output includes:

- child stdout/stderr chunks
- `Debugger.paused` top-frame locations
- `Debugger.scriptParsed` script ids, URLs, lengths, and execution contexts

The test also passes `--timeout 5000` so this failure mode reports in 5s
instead of waiting for the default 30s timeout.

Refs: https://github.com/nodejs/node/actions/runs/27271444902/job/80541641336