### PR TITLE
debugger: wait for initial break output

### DIFF
--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -25,6 +25,7 @@ const {
   Promise,
   PromisePrototypeThen,
   PromiseResolve,
+  PromiseWithResolvers,
   ReflectGetOwnPropertyDescriptor,
   ReflectOwnKeys,
   RegExpPrototypeExec,
@@ -380,6 +381,7 @@ function createRepl(inspector) {
   let selectedFrame;
   let exitDebugRepl;
   let contextLineNumber = 2;
+  let initialBreakRender;
 
   function resetOnStart() {
     knownScripts = {};
@@ -890,6 +892,17 @@ function createRepl(inspector) {
       });
   }
 
+  function createInitialBreakRenderPromise() {
+    if (!inspector.options.script ||
+        process.env.NODE_INSPECT_RESUME_ON_START === '1') {
+      return null;
+    }
+
+    const { promise, resolve, reject } = PromiseWithResolvers();
+    initialBreakRender = { resolve, reject };
+    return promise;
+  }
+
   Debugger.on('paused', ({ callFrames, reason /* , hitBreakpoints */ }) => {
     if (process.env.NODE_INSPECT_RESUME_ON_START === '1' &&
         reason === 'Break on start') {
@@ -910,7 +923,7 @@ function createRepl(inspector) {
 
     const header = `${breakType} in ${scriptUrl}:${lineNumber + 1}`;
 
-    inspector.suspendReplWhile(() =>
+    const pauseRender = inspector.suspendReplWhile(() =>
       PromisePrototypeThen(
         SafePromiseAllReturnArrayLike([formatWatchers(true), selectedFrame.list(contextLineNumber)]),
         ({ 0: watcherList, 1: context }) => {
@@ -919,6 +932,12 @@ function createRepl(inspector) {
             inspect(context);
           print(`${header}\n${breakContext}`);
         }));
+
+    if (initialBreakRender) {
+      const { resolve, reject } = initialBreakRender;
+      initialBreakRender = null;
+      PromisePrototypeThen(pauseRender, resolve, reject);
+    }
   });
 
   function handleResumed() {
@@ -1186,6 +1205,7 @@ function createRepl(inspector) {
   }
 
   async function initAfterStart() {
+    const initialBreakRenderPromise = createInitialBreakRenderPromise();
     await Runtime.enable();
     await Profiler.enable();
     await Profiler.setSamplingInterval({ interval: 100 });
@@ -1194,7 +1214,8 @@ function createRepl(inspector) {
     await Debugger.setBlackboxPatterns({ patterns: [] });
     await Debugger.setPauseOnExceptions({ state: pauseOnExceptionState });
     await restoreBreakpoints();
-    return Runtime.runIfWaitingForDebugger();
+    await Runtime.runIfWaitingForDebugger();
+    await initialBreakRenderPromise;
   }
 
   return async function startRepl() {


### PR DESCRIPTION
Fixes a debugger CLI startup race where the `debug>` prompt could become
observable before the initial `Break on start in ...` output was rendered.

The debugger REPL now waits for the first pause render to complete after
`Runtime.runIfWaitingForDebugger()` when launching a script. This makes tests
that wait for the initial break output less timing-sensitive on slower CI
machines.

Refs: https://github.com/nodejs/node/actions/runs/27590074758/job/81568759203