### PR TITLE
test: fix debugger probe throwing getter flake

### DIFF
--- a/test/fixtures/debugger/probe-throwing-getter.js
+++ b/test/fixtures/debugger/probe-throwing-getter.js
@@ -13,9 +13,10 @@ function markProbesDone() {
 
 module.exports = { holder, markProbesDone };
 
-globalThis.probeLine1 = 1;
-globalThis.probeLine2 = 2;
-
 const interval = setInterval(() => {
+  // Keep these module bindings visible to probe evaluation from this callback.
+  void holder; void markProbesDone;
+  globalThis.probeLine1 = 1;
+  globalThis.probeLine2 = 2;
   if (probesDone) clearInterval(interval);
 }, 50);

--- a/test/parallel/test-debugger-probe-expression-throws.js
+++ b/test/parallel/test-debugger-probe-expression-throws.js
@@ -12,16 +12,16 @@ const { assertProbeJson } = require('../common/debugger-probe');
 const cwd = fixtures.path('debugger');
 const fixture = 'probe-throwing-getter.js';
 const probes = [
-  { expr: 'holder.throwingGetter', target: { suffix: fixture, line: 16 } },
+  { expr: 'holder.throwingGetter', target: { suffix: fixture, line: 19 } },
   // This clears the interval so the process will exit naturally.
-  { expr: 'markProbesDone()', target: { suffix: fixture, line: 17 } },
+  { expr: 'markProbesDone()', target: { suffix: fixture, line: 20 } },
 ];
 const url = fixtures.fileURL('debugger', fixture).href;
 
 spawnSyncAndExit(process.execPath, [
   'inspect', '--json',
-  '--probe', `${fixture}:16`, '--expr', probes[0].expr,
-  '--probe', `${fixture}:17`, '--expr', probes[1].expr,
+  '--probe', `${fixture}:19`, '--expr', probes[0].expr,
+  '--probe', `${fixture}:20`, '--expr', probes[1].expr,
   fixture,
 ], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   status: 0,
@@ -34,7 +34,7 @@ spawnSyncAndExit(process.execPath, [
         probe: 0,
         event: 'hit',
         hit: 1,
-        location: { url, line: 16, column: 1 },
+        location: { url, line: 19, column: 3 },
         error: {
           message: 'Error: boom\n<stack>',
           details: {
@@ -53,7 +53,7 @@ spawnSyncAndExit(process.execPath, [
         probe: 1,
         event: 'hit',
         hit: 1,
-        location: { url, line: 17, column: 1 },
+        location: { url, line: 20, column: 3 },
         result: { type: 'undefined' },
       }, {
         event: 'completed',


### PR DESCRIPTION
Fixes a flaky debugger probe test seen in the macOS unusual-character path CI rerun.

The fixture previously placed both probe target statements at top level. If the
target script ran before those breakpoints were bound, both probes could be
missed and the fixture would stay alive until probe mode timed out.

This moves the target statements into the fixture's existing interval so they
remain available until the completion probe runs and clears the interval.

Refs: https://github.com/nodejs/node/actions/runs/27588057763/job/81562704514