### PR TITLE
test_runner: suppress failures from watch restarts

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -565,19 +565,28 @@ function runTestFile(path, filesWatcher, opts) {
     // Close readline interface to prevent memory leak
     rl.close();
 
+    const wasRestarted = watchMode && filesWatcher.restartingProcesses.delete(child);
+
     if (watchMode) {
       filesWatcher.runningProcesses.delete(path);
-      filesWatcher.runningSubtests.delete(path);
       (async () => {
         try {
           await subTestEnded;
         } finally {
+          if (filesWatcher.runningSubtests.get(path) === subTestEnded) {
+            filesWatcher.runningSubtests.delete(path);
+          }
           if (filesWatcher.runningSubtests.size === 0) {
             opts.root.reporter[kEmitMessage]('test:watch:drained');
             opts.root.postRun();
           }
         }
       })();
+    }
+
+    if (wasRestarted) {
+      subtest.filtered = true;
+      return;
     }
 
     if (code !== 0 || signal !== null) {
@@ -603,27 +612,53 @@ function runTestFile(path, filesWatcher, opts) {
 function watchFiles(testFiles, opts) {
   const runningProcesses = new SafeMap();
   const runningSubtests = new SafeMap();
+  const restartingProcesses = new SafeSet();
   const watcherMode = opts.hasFiles ? 'filter' : 'all';
   const watcher = new FilesWatcher({ __proto__: null, debounce: 200, mode: watcherMode, signal: opts.signal });
   if (!opts.hasFiles) {
     watcher.watchPath(opts.cwd);
   }
-  const filesWatcher = { __proto__: null, watcher, runningProcesses, runningSubtests };
+  const filesWatcher = { __proto__: null, watcher, runningProcesses, runningSubtests, restartingProcesses };
   opts.root.harness.watching = true;
 
-  async function restartTestFile(file) {
-    const runningProcess = runningProcesses.get(file);
-    if (runningProcess) {
-      runningProcess.kill();
-      await once(runningProcess, 'exit');
-    }
-    if (!runningSubtests.size) {
-      // Reset the topLevel counter
-      opts.root.harness.counters.topLevel = 0;
+  async function restartTestFiles(files) {
+    if (files.length === 0) {
+      return;
     }
 
-    await runningSubtests.get(file);
-    runningSubtests.set(file, runTestFile(file, filesWatcher, opts));
+    const previousSubtests = new SafeMap();
+    const restartPromises = new SafeMap();
+
+    ArrayPrototypeForEach(files, (file) => {
+      const restart = PromiseWithResolvers();
+      previousSubtests.set(file, runningSubtests.get(file));
+      restartPromises.set(file, restart);
+      runningSubtests.set(file, restart.promise);
+    });
+
+    await SafePromiseAllReturnVoid(files, async (file) => {
+      const runningProcess = runningProcesses.get(file);
+      if (runningProcess) {
+        restartingProcesses.add(runningProcess);
+        runningProcess.kill();
+        if (runningProcess.exitCode === null && runningProcess.signalCode === null) {
+          await once(runningProcess, 'exit');
+        }
+      }
+      await previousSubtests.get(file);
+    });
+
+    opts.root.harness.resetCounters();
+
+    ArrayPrototypeForEach(files, (file) => {
+      const restart = restartPromises.get(file);
+
+      if (runningSubtests.get(file) === restart.promise) {
+        runningSubtests.set(file, runTestFile(file, filesWatcher, opts));
+      }
+
+      restart.resolve();
+    });
   }
 
   // Watch for changes in current filtered files
@@ -653,20 +688,15 @@ function watchFiles(testFiles, opts) {
 
     // Restart test files
     if (opts.isolation === 'none') {
-      PromisePrototypeThen(restartTestFile(kIsolatedProcessName), undefined, (error) => {
+      PromisePrototypeThen(restartTestFiles([kIsolatedProcessName]), undefined, (error) => {
         triggerUncaughtException(error, true /* fromPromise */);
       });
     } else {
       watcher.unfilterFilesOwnedBy(owners);
-      PromisePrototypeThen(SafePromiseAllReturnVoid(testFiles, async (file) => {
-        if (!owners.has(file)) {
-          return;
-        }
-
-        await restartTestFile(file);
-      }, undefined, (error) => {
+      const filesToRestart = ArrayPrototypeFilter(testFiles, (file) => owners.has(file));
+      PromisePrototypeThen(restartTestFiles(filesToRestart), undefined, (error) => {
         triggerUncaughtException(error, true /* fromPromise */);
-      }));
+      });
     }
   };
 

--- a/test/test-runner/test-run-watch-restart-running-process.mjs
+++ b/test/test-runner/test-run-watch-restart-running-process.mjs
@@ -1,0 +1,101 @@
+// Test run({ watch: true }) does not report a failure when watch mode kills a
+// running test process to restart it.
+import * as common from '../common/index.mjs';
+import { run } from 'node:test';
+import assert from 'node:assert';
+import { existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import tmpdir from '../common/tmpdir.js';
+import { skipIfNoWatch } from '../common/watch.js';
+
+skipIfNoWatch();
+tmpdir.refresh();
+
+const testFile = join(tmpdir.path, 'test.js');
+const slowTestStarted = join(tmpdir.path, 'slow-test-started');
+const fastTest = `
+const test = require('node:test');
+test('fast test');
+`;
+const slowTest = `
+const test = require('node:test');
+const { writeFileSync } = require('node:fs');
+const { setTimeout } = require('node:timers/promises');
+writeFileSync(${JSON.stringify(slowTestStarted)}, 'started');
+test('slow test', async () => setTimeout(30_000));
+`;
+
+writeFileSync(testFile, fastTest);
+
+let drains = 0;
+let restarts = 0;
+let wroteSlowTest = false;
+let wroteFinalTest = false;
+let completed = false;
+const failures = [];
+const controller = new AbortController();
+const timeout = setTimeout(() => controller.abort(), common.platformTimeout(10_000));
+timeout.unref();
+let markerInterval;
+
+function writeFinalTestWhenSlowTestStarts() {
+  if (markerInterval !== undefined) {
+    return;
+  }
+
+  markerInterval = setInterval(() => {
+    if (!existsSync(slowTestStarted)) {
+      return;
+    }
+
+    clearInterval(markerInterval);
+    markerInterval = undefined;
+    wroteFinalTest = true;
+    writeFileSync(testFile, fastTest);
+  }, common.platformTimeout(100));
+  markerInterval.unref();
+}
+
+const stream = run({
+  cwd: tmpdir.path,
+  watch: true,
+  signal: controller.signal,
+  isolation: 'process',
+}).on('data', ({ type, data }) => {
+  if (type === 'test:fail') {
+    failures.push(data);
+  }
+
+  if (type === 'test:watch:restarted') {
+    restarts++;
+  }
+
+  if (type === 'test:watch:drained') {
+    drains++;
+
+    if (!wroteSlowTest) {
+      wroteSlowTest = true;
+      writeFileSync(testFile, slowTest);
+      writeFinalTestWhenSlowTestStarts();
+      return;
+    }
+
+    if (wroteFinalTest) {
+      completed = true;
+      controller.abort();
+    }
+  }
+});
+
+// eslint-disable-next-line no-unused-vars
+for await (const _ of stream);
+
+clearTimeout(timeout);
+if (markerInterval !== undefined) {
+  clearInterval(markerInterval);
+}
+
+assert.strictEqual(completed, true);
+assert.strictEqual(drains, 2);
+assert.ok(restarts >= 2);
+assert.deepStrictEqual(failures, []);


### PR DESCRIPTION
Fix a watch mode race where an intentionally killed test child process could be
reported as a failing test file during restart.

When a watched file changes while its test process is still running, watch mode
kills that child before starting the replacement run. The old child exit was
being treated as a normal failure, which could produce output like `✖ test.js`
even though the process was killed by the runner itself.

This change tracks restart-killed child processes, suppresses those exits as
failures, and keeps restart bookkeeping active until the replacement run is
registered.

Refs: https://github.com/nodejs/reliability/issues?q=%22parallel%2Ftest-runner-watch-mode%22

<details>
<summary>Error Log</summary>

```console
not ok 2777 parallel/test-runner-watch-mode
  ---
  duration_ms: 34634.36900
  severity: fail
  exitcode: 1
  stack: |-
    Test failure: 'should run new tests when a new file is created in the watched directory'
    Location: test/parallel/test-runner-watch-mode.mjs:195:7
    AssertionError [ERR_ASSERTION]: The input did not match the regular expression /tests 1/. Input:
    
    '✔ new-test-file.test.js (1.308279ms)\n' +
      '✔ test has ran (0.160193ms)\n' +
      'ℹ tests 2\n' +
      'ℹ suites 0\n' +
      'ℹ pass 2\n' +
      'ℹ fail 0\n' +
      'ℹ cancelled 0\n' +
      'ℹ skipped 0\n' +
      'ℹ todo 0\n' +
      'ℹ duration_ms 216.114222\n'
    
        at testCreate (file:///Users/admin/build/workspace/node-test-commit-osx/nodes/osx13-x64/test/parallel/test-runner-watch-mode.mjs:154:14)
        at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
        at async testWatch (file:///Users/admin/build/workspace/node-test-commit-osx/nodes/osx13-x64/test/parallel/test-runner-watch-mode.mjs:164:26)
        at async TestContext.<anonymous> (file:///Users/admin/build/workspace/node-test-commit-osx/nodes/osx13-x64/test/parallel/test-runner-watch-mode.mjs:200:9)
        at async Test.run (node:internal/test_runner/test:1054:7)
        at async Suite.processPendingSubtests (node:internal/test_runner/test:744:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: '✔ new-test-file.test.js (1.308279ms)\n' +
        '✔ test has ran (0.160193ms)\n' +
        'ℹ tests 2\n' +
        'ℹ suites 0\n' +
        'ℹ pass 2\n' +
        'ℹ fail 0\n' +
        'ℹ cancelled 0\n' +
        'ℹ skipped 0\n' +
        'ℹ todo 0\n' +
        'ℹ duration_ms 216.114222\n' +
        '...',
      expected: /tests 1/,
      operator: 'match',
      diff: 'simple'
    }
    
    Test failure: 'should support running tests without a file'
    Location: test/parallel/test-runner-watch-mode.mjs:183:7
    AssertionError [ERR_ASSERTION]: The input did not match the regular expression /tests 1/. Input:
    
    '✖ test.js (1097.817111ms)\n' +
      '✔ test has ran (1.111652ms)\n' +
      'ℹ tests 2\n' +
      'ℹ suites 0\n' +
      'ℹ pass 1\n' +
      'ℹ fail 1\n' +
      'ℹ cancelled 0\n' +
      'ℹ skipped 0\n' +
      'ℹ todo 0\n' +
      'ℹ duration_ms 486.007065\n' +
      '\n' +
      '✖ failing tests:\n' +
      '\n' +
      'test at test.js:1:1\n' +
      '✖ test.js (1097.817111ms)\n' +
      "  'test failed'\n"
    
        at testUpdate (file:///Users/admin/build/workspace/node-test-commit-osx/nodes/osx13-x64/test/parallel/test-runner-watch-mode.mjs:80:14)
        at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
        at async testWatch (file:///Users/admin/build/workspace/node-test-commit-osx/nodes/osx13-x64/test/parallel/test-runner-watch-mode.mjs:161:26)
        at async TestContext.<anonymous> (file:///Users/admin/build/workspace/node-test-commit-osx/nodes/osx13-x64/test/parallel/test-runner-watch-mode.mjs:184:9)
        at async Test.run (node:internal/test_runner/test:1054:7)
        at async Suite.processPendingSubtests (node:internal/test_runner/test:744:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: '✖ test.js (1097.817111ms)\n' +
        '✔ test has ran (1.111652ms)\n' +
        'ℹ tests 2\n' +
        'ℹ suites 0\n' +
        'ℹ pass 1\n' +
        'ℹ fail 1\n' +
        'ℹ cancelled 0\n' +
        'ℹ skipped 0\n' +
        'ℹ todo 0\n' +
        'ℹ duration_ms 486.007065\n' +
        '...',
      expected: /tests 1/,
      operator: 'match',
      diff: 'simple'
    }
    
  ...
```

</details>

---

Assisted-by: openai:gpt-5.5