### PR TITLE
test: wait for debugger pause state on startup

### DIFF
--- a/test/common/debugger.js
+++ b/test/common/debugger.js
@@ -6,6 +6,7 @@ const BREAK_MESSAGE = new RegExp('(?:' + [
   'assert', 'break', 'break on start', 'debugCommand',
   'exception', 'other', 'promiseRejection', 'step',
 ].join('|') + ') in', 'i');
+const NOT_PAUSED_MESSAGE = /requires execution to be paused/i;
 
 let TIMEOUT = common.platformTimeout(10000);
 // Some macOS and Windows machines require more time to receive the outputs from the client.
@@ -56,7 +57,7 @@ function startCLI(args, flags = [], spawnOpts = {}, opts = { randomPort: true })
       return output;
     },
 
-    waitFor(pattern) {
+    waitFor(pattern, offset = 0, timeout = TIMEOUT) {
       function checkPattern(str) {
         if (Array.isArray(pattern)) {
           return pattern.every((p) => p.test(str));
@@ -66,9 +67,10 @@ function startCLI(args, flags = [], spawnOpts = {}, opts = { randomPort: true })
 
       return new Promise((resolve, reject) => {
         function checkOutput() {
-          if (checkPattern(getOutput())) {
+          const output = getOutput().slice(offset);
+          if (checkPattern(output)) {
             tearDown();
-            resolve();
+            resolve(output);
           }
         }
 
@@ -89,12 +91,12 @@ function startCLI(args, flags = [], spawnOpts = {}, opts = { randomPort: true })
         }
 
         // Capture stack trace here to show where waitFor was called from when it times out.
-        const timeoutErr = new Error(`Timeout (${TIMEOUT}) while waiting for ${pattern}`);
+        const timeoutErr = new Error(`Timeout (${timeout}) while waiting for ${pattern}`);
         const timer = setTimeout(() => {
           tearDown();
           timeoutErr.output = this.output;
           reject(timeoutErr);
-        }, TIMEOUT);
+        }, timeout);
 
         function tearDown() {
           clearTimeout(timer);
@@ -108,16 +110,44 @@ function startCLI(args, flags = [], spawnOpts = {}, opts = { randomPort: true })
       });
     },
 
-    waitForPrompt() {
-      return this.waitFor(/>\s+$/);
+    async waitForPaused() {
+      const deadline = Date.now() + TIMEOUT;
+
+      function getRemainingTime() {
+        return deadline - Date.now();
+      }
+
+      await this.waitForPrompt(getRemainingTime());
+
+      while (getRemainingTime() > 0) {
+        const offset = this.output.length;
+        this.writeLine('list()', false);
+        const output = await this.waitFor(/>\s+$/, offset, getRemainingTime());
+
+        if (!NOT_PAUSED_MESSAGE.test(output)) {
+          return;
+        }
+
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.min(100, getRemainingTime())));
+      }
+
+      const timeoutErr =
+        new Error(`Timeout (${TIMEOUT}) while waiting for a debugger pause state`);
+      timeoutErr.output = this.output;
+      throw timeoutErr;
+    },
+
+    waitForPrompt(timeout = TIMEOUT) {
+      return this.waitFor(/>\s+$/, 0, timeout);
     },
 
     async waitForInitialBreak() {
-      await this.waitFor(/break (?:on start )?in/i);
+      await this.waitForPaused();
 
       if (isPreBreak(this.output)) {
         await this.command('next', false);
-        return this.waitFor(/break in/);
+        await this.waitForPaused();
       }
     },
 


### PR DESCRIPTION
This updates the debugger test helper to wait for the debugger CLI
to reach a paused state instead of depending only on the printed
initial break banner.

The helper now probes with `list()` and retries while the CLI reports
that execution is not paused. Each probe wait uses the remaining
timeout budget so the overall startup wait still respects the helper
timeout.

Refs: https://github.com/nodejs/node/actions/runs/27683841143/job/81877654047

<details>
<summary>Error log</summary>

```
Path: parallel/test-debugger-exec-scope
Error: --- stderr ---
/Users/runner/work/node/node/node/test/common/debugger.js:92
        const timeoutErr = new Error(`Timeout (${TIMEOUT}) while waiting for ${pattern}`);
                           ^

Error: Timeout (15000) while waiting for /break (?:on start )?in/i
    at /Users/runner/work/node/node/node/test/common/debugger.js:92:28
    at new Promise (<anonymous>)
    at Object.waitFor (/Users/runner/work/node/node/node/test/common/debugger.js:67:14)
    at Object.waitForInitialBreak (/Users/runner/work/node/node/node/test/common/debugger.js:116:18)
    at file:///Users/runner/work/node/node/node/test/parallel/test-debugger-exec-scope.mjs:13:13
    at ModuleJob.run (node:internal/modules/esm/module_job:447:25)
    at async node:internal/modules/esm/loader:646:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5) {
  output: '\n' +
    '< Debugger listening on ws://127.0.0.1:55107/b43be8c5-442d-49a8-80ce-1ff2d58af386\n' +
    '< For help, see: https://nodejs.org/learn/getting-started/debugging\n' +
    '< \n' +
    'connecting to 127.0.0.1:55107 ...\n' +
    '< Debugger attached.\n' +
    '< \n' +
    '\n' +
    ' ok\n' +
    '\n' +
    'debug> '
}
```

Details: https://github.com/nodejs/node/actions/runs/27683841143/job/81877654047

</details>