### PR TITLE
test_runner: improve coverage source map diagnostics

### DIFF
--- a/test/parallel/test-runner-coverage-source-map.js
+++ b/test/parallel/test-runner-coverage-source-map.js
@@ -6,6 +6,9 @@ common.skipIfInspectorDisabled();
 
 const { describe, it } = require('node:test');
 
+const spawnEnv = { ...process.env, NO_COLOR: '1' };
+delete spawnEnv.FORCE_COLOR;
+
 function generateReport(report) {
   report = ([
     '# start of coverage report',
@@ -16,6 +19,21 @@ function generateReport(report) {
     report = report.replaceAll('/', '\\');
   }
   return report;
+}
+
+function assertIncludes(t, stdout, expected) {
+  t.assert.ok(
+    stdout.includes(expected),
+    `Expected stdout to include:\n${expected}\nActual stdout:\n${stdout}`,
+  );
+}
+
+function spawnNode(args, options = {}) {
+  return common.spawnPromisified(process.execPath, args, {
+    __proto__: null,
+    ...options,
+    env: { __proto__: null, ...spawnEnv, ...options.env },
+  });
 }
 
 const flags = [
@@ -43,12 +61,12 @@ describe('Coverage with source maps', async () => {
       '# --------------------------------------------------------------',
     ]);
 
-    const spawned = await common.spawnPromisified(process.execPath, flags, {
+    const spawned = await spawnNode(flags, {
       cwd: fixtures.path('test-runner', 'coverage')
     });
 
     t.assert.strictEqual(spawned.stderr, '');
-    t.assert.ok(spawned.stdout.includes(report));
+    assertIncludes(t, spawned.stdout, report);
     t.assert.strictEqual(spawned.code, 1);
   });
 
@@ -65,11 +83,11 @@ describe('Coverage with source maps', async () => {
       '# --------------------------------------------------------------',
     ]);
 
-    const spawned = await common.spawnPromisified(process.execPath, flags.slice(1), {
+    const spawned = await spawnNode(flags.slice(1), {
       cwd: fixtures.path('test-runner', 'coverage')
     });
     t.assert.strictEqual(spawned.stderr, '');
-    t.assert.ok(spawned.stdout.includes(report));
+    assertIncludes(t, spawned.stdout, report);
     t.assert.strictEqual(spawned.code, 1);
   });
 
@@ -86,7 +104,7 @@ describe('Coverage with source maps', async () => {
       '# ----------------------------------------------------------',
     ]);
 
-    const spawned = await common.spawnPromisified(process.execPath, [
+    const spawned = await spawnNode([
       ...flags,
       'test.mjs',
     ], {
@@ -94,7 +112,7 @@ describe('Coverage with source maps', async () => {
     });
 
     t.assert.strictEqual(spawned.stderr, '');
-    t.assert.ok(spawned.stdout.includes(report));
+    assertIncludes(t, spawned.stdout, report);
     t.assert.strictEqual(spawned.code, 0);
   });
 
@@ -114,23 +132,23 @@ describe('Coverage with source maps', async () => {
       '# ------------------------------------------------------------------',
     ]);
 
-    const spawned = await common.spawnPromisified(process.execPath, [
+    const spawned = await spawnNode([
       ...flags,
       fixtures.path('test-runner', 'source-maps', 'line-lengths', 'index.js'),
     ]);
     t.assert.strictEqual(spawned.stderr, '');
-    t.assert.ok(spawned.stdout.includes(report));
+    assertIncludes(t, spawned.stdout, report);
     t.assert.strictEqual(spawned.code, 0);
   });
 
   await it('should throw when a source map is missing a source file', async (t) => {
     const file = fixtures.path('test-runner', 'source-maps', 'missing-sources', 'index.js');
     const missing = fixtures.path('test-runner', 'source-maps', 'missing-sources', 'nonexistent.js');
-    const spawned = await common.spawnPromisified(process.execPath, [...flags, file]);
+    const spawned = await spawnNode([...flags, file]);
 
     const error = `Cannot find '${pathToFileURL(missing)}' imported from the source map for '${pathToFileURL(file)}'`;
     t.assert.strictEqual(spawned.stderr, '');
-    t.assert.ok(spawned.stdout.includes(error));
+    assertIncludes(t, spawned.stdout, error);
     t.assert.strictEqual(spawned.code, 1);
   });
 
@@ -139,11 +157,11 @@ describe('Coverage with source maps', async () => {
     [fixtures.path('test-runner', 'source-maps', 'missing-map.js'), 'does not exist'],
   ]) {
     await it(`should throw when a source map ${message}`, async (t) => {
-      const spawned = await common.spawnPromisified(process.execPath, [...flags, file]);
+      const spawned = await spawnNode([...flags, file]);
 
       const error = `The source map for '${pathToFileURL(file)}' does not exist or is corrupt`;
       t.assert.strictEqual(spawned.stderr, '');
-      t.assert.ok(spawned.stdout.includes(error));
+      assertIncludes(t, spawned.stdout, error);
       t.assert.strictEqual(spawned.code, 1);
     });
   }


### PR DESCRIPTION
Refs: https://github.com/nodejs/reliability/issues?q=sort%3Aupdated-desc%20is%3Aissue%20state%3Aopen%20%22test-runner-coverage-source-map%22

<details>
<summary>Example</summary>

```console
not ok 3925 parallel/test-runner-coverage-source-map
  ---
  duration_ms: 1652.14700
  severity: fail
  exitcode: 1
  stack: |-
    Test failure: 'should work with source maps'
    Location: test/parallel/test-runner-coverage-source-map.js:32:9
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      t.assert.ok(spawned.stdout.includes(report))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage-source-map.js:51:14)
        at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
        at async Test.run (node:internal/test_runner/test:1389:7)
        at async Promise.all (index 0)
        at async Suite.run (node:internal/test_runner/test:1869:7)
        at async startSubtestAfterBootstrap (node:internal/test_runner/harness:387:3) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'should only work with --enable-source-maps'
    Location: test/parallel/test-runner-coverage-source-map.js:55:9
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      t.assert.ok(spawned.stdout.includes(report))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage-source-map.js:72:14)
        at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
        at async Test.run (node:internal/test_runner/test:1389:7)
        at async Suite.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'should ignore erased TypeScript import type lines'
    Location: test/parallel/test-runner-coverage-source-map.js:76:9
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      t.assert.ok(spawned.stdout.includes(report))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage-source-map.js:97:14)
        at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
        at async Test.run (node:internal/test_runner/test:1389:7)
        at async Suite.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'properly accounts for line endings in source maps'
    Location: test/parallel/test-runner-coverage-source-map.js:101:9
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      t.assert.ok(spawned.stdout.includes(report))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage-source-map.js:122:14)
        at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
        at async Test.run (node:internal/test_runner/test:1389:7)
        at async Suite.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'should throw when a source map is missing a source file'
    Location: test/parallel/test-runner-coverage-source-map.js:126:9
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      t.assert.ok(spawned.stdout.includes(error))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage-source-map.js:133:14)
        at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
        at async Test.run (node:internal/test_runner/test:1389:7)
        at async Suite.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'should throw when a source map is not valid JSON'
    Location: test/parallel/test-runner-coverage-source-map.js:141:11
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      t.assert.ok(spawned.stdout.includes(error))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage-source-map.js:146:16)
        at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
        at async Test.run (node:internal/test_runner/test:1389:7)
        at async Suite.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'should throw when a source map does not exist'
    Location: test/parallel/test-runner-coverage-source-map.js:141:11
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      t.assert.ok(spawned.stdout.includes(error))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage-source-map.js:146:16)
        at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
        at async Test.run (node:internal/test_runner/test:1389:7)
        at async Suite.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
```

</details>