### PR TITLE
worker: wake web lock waiters after env cleanup

### DIFF
--- a/src/node_locks.cc
+++ b/src/node_locks.cc
@@ -765,6 +765,7 @@ void LockManager::WakeEnvironment(Environment* target_env) {
 // Remove all held locks and pending requests that belong to an Environment
 // that is being destroyed
 void LockManager::CleanupEnvironment(Environment* env_to_cleanup) {
+  std::unordered_set<Environment*> envs_to_wake;
   Mutex::ScopedLock scoped_lock(mutex_);
 
   // Remove every held lock that belongs to this Environment.
@@ -786,6 +787,13 @@ void LockManager::CleanupEnvironment(Environment* env_to_cleanup) {
     }
   }
 
+  for (const auto& pending_request : pending_queue_) {
+    Environment* pending_env = pending_request->env();
+    if (pending_env != env_to_cleanup) {
+      envs_to_wake.insert(pending_env);
+    }
+  }
+
   // Remove every pending request submitted by this Environment.
   for (auto request_iter = pending_queue_.begin();
        request_iter != pending_queue_.end();) {
@@ -798,6 +806,13 @@ void LockManager::CleanupEnvironment(Environment* env_to_cleanup) {
 
   // Finally, remove it from registered_envs_
   registered_envs_.erase(env_to_cleanup);
+
+  {
+    Mutex::ScopedUnlock unlock(scoped_lock);
+    for (Environment* env : envs_to_wake) {
+      WakeEnvironment(env);
+    }
+  }
 }
 
 // Cleanup hook wrapper

--- a/test/parallel/test-web-locks.js
+++ b/test/parallel/test-web-locks.js
@@ -4,6 +4,7 @@
 const common = require('../common');
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
+const { setTimeout: sleep } = require('node:timers/promises');
 const { Worker } = require('node:worker_threads');
 const { AsyncLocalStorage } = require('node:async_hooks');
 
@@ -220,5 +221,38 @@ describe('Web Locks with worker threads', () => {
     await navigator.locks.request('cleanup-test', common.mustCall(async (lock) => {
       assert.strictEqual(lock.name, 'cleanup-test');
     }));
+  });
+
+  it('should wake a pending lock request when worker owning lock terminates', async () => {
+    const worker = new Worker(`
+      const { parentPort } = require('worker_threads');
+
+      navigator.locks.request('cleanup-held-test', async () => {
+        parentPort.postMessage({ acquired: true });
+        await new Promise(() => {});
+      });
+    `, { eval: true });
+
+    const acquired = await new Promise((resolve) => {
+      worker.once('message', resolve);
+    });
+    assert.strictEqual(acquired.acquired, true);
+
+    const pending = navigator.locks.request(
+      'cleanup-held-test',
+      common.mustCall(async (lock) => {
+        assert.strictEqual(lock.name, 'cleanup-held-test');
+        return 'acquired-after-cleanup';
+      }));
+
+    await worker.terminate();
+
+    const result = await Promise.race([
+      pending,
+      sleep(common.platformTimeout(1000)).then(() => {
+        throw new Error('Timed out waiting for pending lock after worker cleanup');
+      }),
+    ]);
+    assert.strictEqual(result, 'acquired-after-cleanup');
   });
 });


### PR DESCRIPTION
When a worker exits while holding a Web Lock, cleanup removes the held lock but did not wake other environments with pending requests. This could leave the waiter pending until the test runner timed out.

Wake pending environments after removing the terminating environment's held locks and queued requests.
